### PR TITLE
add FLTO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,18 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 # Report the build type
 message("CMAKE_BUILD_TYPE is ${CMAKE_BUILD_TYPE}")
 
+# Test for -flto support
+include(CheckCXXCompilerFlag)
+include(CheckCCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-flto CXX_SUPPORTS_FLTO)
+CHECK_C_COMPILER_FLAG(-flto C_SUPPORTS_FLTO)
+if(CXX_SUPPORTS_FLTO AND C_SUPPORTS_FLTO)
+    message(STATUS "Compiling with FLTO support")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+endif()
+
 # GSL 
 set(TARGET_NAME gsl)
 file(GLOB_RECURSE GSL_SOURCES ${PROJECT_SOURCE_DIR}/gsl/*.c ${PROJECT_SOURCE_DIR}/gsl/*/*.c)


### PR DESCRIPTION
Adds -lfto support when available to the compiler.  In light of #26, this will make sure that it happens for both OS X and Linux bioconda builds.