### PR TITLE
enable pedigree id access when treeseq is enabled

### DIFF
--- a/core/genome.cpp
+++ b/core/genome.cpp
@@ -549,7 +549,7 @@ EidosValue_SP Genome::GetProperty(EidosGlobalStringID p_property_id)
 		case gID_genomePedigreeID:		// ACCELERATED
 		{
 			if (!subpop_->population_.sim_.PedigreesEnabledByUser())
-				EIDOS_TERMINATION << "ERROR (Genome::GetProperty): property genomePedigreeID is not available because pedigree recording has not been enabled." << EidosTerminate();
+				EIDOS_TERMINATION << "ERROR (Genome::GetProperty): tree sequence recording and/or pedigree recording must be enabled for property genomePedigreeID to be available." << EidosTerminate();
 			
 			return EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Int_singleton(genome_id_));
 		}
@@ -612,8 +612,9 @@ EidosValue *Genome::GetProperty_Accelerated_genomePedigreeID(EidosObjectElement 
 	{
 		Genome *value = (Genome *)(p_values[value_index]);
 		
-		if (!value->subpop_->population_.sim_.PedigreesEnabledByUser())
-			EIDOS_TERMINATION << "ERROR (Genome::GetProperty): property genomePedigreeID is not available because pedigree recording has not been enabled." << EidosTerminate();
+		if (!(value->subpop_->population_.sim_.PedigreesEnabledByUser()
+              || value->subpop_->population_.sim_.RecordingTreeSequence()))
+			EIDOS_TERMINATION << "ERROR (Genome::GetProperty): tree sequence recording and/or pedigree recording must be enabled for property genomePedigreeID to be available." << EidosTerminate();
 		
 		int_result->set_int_no_check(value->genome_id_, value_index);
 		++value_index;

--- a/core/individual.cpp
+++ b/core/individual.cpp
@@ -216,8 +216,9 @@ EidosValue_SP Individual::GetProperty(EidosGlobalStringID p_property_id)
 #endif  // SLIM_NONWF_ONLY
 		case gID_pedigreeID:		// ACCELERATED
 		{
-			if (!subpopulation_.population_.sim_.PedigreesEnabledByUser())
-				EIDOS_TERMINATION << "ERROR (Individual::GetProperty): property pedigreeID is not available because pedigree recording has not been enabled." << EidosTerminate();
+			if (!(subpopulation_.population_.sim_.PedigreesEnabledByUser()
+                  || subpopulation_.population_.sim_.RecordingTreeSequence()))
+				EIDOS_TERMINATION << "ERROR (Individual::GetProperty): tree sequence recording and/or pedigree recording must be enabled for property genomePedigreeID to be available." << EidosTerminate();
 			
 			return EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Int_singleton(pedigree_id_));
 		}
@@ -486,8 +487,9 @@ EidosValue *Individual::GetProperty_Accelerated_pedigreeID(EidosObjectElement **
 	{
 		Individual *value = (Individual *)(p_values[value_index]);
 		
-		if (!value->subpopulation_.population_.sim_.PedigreesEnabledByUser())
-			EIDOS_TERMINATION << "ERROR (Individual::GetProperty): property pedigreeID is not available because pedigree recording has not been enabled." << EidosTerminate();
+		if (!(value->subpopulation_.population_.sim_.PedigreesEnabledByUser()
+              || value->subpopulation_.population_.sim_.RecordingTreeSequence()))
+			EIDOS_TERMINATION << "ERROR (Individual::GetProperty): tree sequence recording and/or pedigree recording must be enabled for property genomePedigreeID to be available." << EidosTerminate();
 		
 		int_result->set_int_no_check(value->pedigree_id_, value_index);
 		++value_index;


### PR DESCRIPTION
When treeseq is enabled, we have pedigree IDs, so that every individual has a unique ID. These we get to see in the output, in the individual metadata. However, they're not available in Eidos because at the various places it might be obtained there's a check to see if pedigree recording is enabled. (e.g. [here](https://github.com/MesserLab/SLiM/blob/6d543b6337398996de4d95181128a9a52117175e/core/individual.cpp#L220)).  This allows access when tree sequence recording is enabled also, which is important for being able to connect the individuals in SLiM to the individuals in the tree sequence. The docs would need to be updated also.