### PR TITLE
Added the Eidos function qnorm() and accompanying test functions

### DIFF
--- a/eidos/eidos_functions.cpp
+++ b/eidos/eidos_functions.cpp
@@ -159,6 +159,7 @@ const std::vector<EidosFunctionSignature_CSP> &EidosInterpreter::BuiltInFunction
 		
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("dmvnorm",			Eidos_ExecuteFunction_dmvnorm,		kEidosValueMaskFloat))->AddFloat("x")->AddNumeric("mu")->AddNumeric("sigma"));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("dnorm",				Eidos_ExecuteFunction_dnorm,		kEidosValueMaskFloat))->AddFloat("x")->AddNumeric_O("mean", gStaticEidosValue_Float0)->AddNumeric_O("sd", gStaticEidosValue_Float1));
+		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("qnorm",				Eidos_ExecuteFunction_qnorm,		kEidosValueMaskFloat))->AddFloat("p")->AddNumeric_O("mean", gStaticEidosValue_Float0)->AddNumeric_O("sd", gStaticEidosValue_Float1));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("pnorm",				Eidos_ExecuteFunction_pnorm,		kEidosValueMaskFloat))->AddFloat("q")->AddNumeric_O("mean", gStaticEidosValue_Float0)->AddNumeric_O("sd", gStaticEidosValue_Float1));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("rbeta",				Eidos_ExecuteFunction_rbeta,		kEidosValueMaskFloat))->AddInt_S(gEidosStr_n)->AddNumeric("alpha")->AddNumeric("beta"));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("rbinom",			Eidos_ExecuteFunction_rbinom,		kEidosValueMaskInt))->AddInt_S(gEidosStr_n)->AddInt("size")->AddFloat("prob"));
@@ -4692,6 +4693,80 @@ EidosValue_SP Eidos_ExecuteFunction_dnorm(const EidosValue_SP *const p_arguments
 	
 	return result_SP;
 }
+
+//	(float)qnorm(float p, [numeric mean = 0], [numeric sd = 1])
+EidosValue_SP Eidos_ExecuteFunction_qnorm(const EidosValue_SP *const p_arguments, __attribute__((unused)) int p_argument_count, __attribute__((unused)) EidosInterpreter &p_interpreter)
+{
+	// Note that this function ignores matrix/array attributes, and always returns a vector, by design
+	
+	EidosValue_SP result_SP(nullptr);
+	
+	EidosValue *arg_prob = p_arguments[0].get();
+	EidosValue *arg_mu = p_arguments[1].get();
+	EidosValue *arg_sigma = p_arguments[2].get();
+	int64_t num_probs = arg_prob->Count();
+	int arg_mu_count = arg_mu->Count();
+	int arg_sigma_count = arg_sigma->Count();
+	bool mu_singleton = (arg_mu_count == 1);
+	bool sigma_singleton = (arg_sigma_count == 1);
+	
+	if (!mu_singleton && (arg_mu_count != num_probs))
+		EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires mean to be of length 1 or equal in length to x." << EidosTerminate(nullptr);
+	if (!sigma_singleton && (arg_sigma_count != num_probs))
+		EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires sd to be of length 1 or equal in length to x." << EidosTerminate(nullptr);
+	
+	double mu0 = (arg_mu_count ? arg_mu->FloatAtIndex(0, nullptr) : 0.0);
+	double sigma0 = (arg_sigma_count ? arg_sigma->FloatAtIndex(0, nullptr) : 1.0);
+	
+	if (mu_singleton && sigma_singleton)
+	{
+		if (sigma0 <= 0.0)
+			EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires sd > 0.0 (" << EidosStringForFloat(sigma0) << " supplied)." << EidosTerminate(nullptr);
+		
+		if (num_probs == 1)
+		{
+			const double float_prob = arg_prob->FloatAtIndex(0, nullptr);
+			if (float_prob < 0.0 || float_prob > 1.0)
+				EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_dnorm): function qnorm() requires 0.0 <= p <= 1.0 (" << EidosStringForFloat(float_prob) << " supplied)." << EidosTerminate(nullptr);
+
+			result_SP = EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Float_singleton(gsl_cdf_gaussian_Pinv(float_prob, sigma0) + mu0));
+		}
+		else
+		{
+			const double *float_data = arg_prob->FloatVector()->data();
+			EidosValue_Float_vector *float_result = (new (gEidosValuePool->AllocateChunk()) EidosValue_Float_vector())->resize_no_initialize(num_probs);
+			result_SP = EidosValue_SP(float_result);
+			
+			for (int64_t value_index = 0; value_index < num_probs; ++value_index) {
+				if (float_data[value_index] < 0.0 || float_data[value_index] > 1.0)
+					EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires 0.0 <= p <= 1.0 (" << EidosStringForFloat(float_data[value_index]) << " supplied)." << EidosTerminate(nullptr);
+				float_result->set_float_no_check(gsl_cdf_gaussian_Pinv(float_data[value_index], sigma0) + mu0, value_index);
+        }
+		}
+	}
+	else
+	{
+		const double *float_data = arg_prob->FloatVector()->data();
+		EidosValue_Float_vector *float_result = (new (gEidosValuePool->AllocateChunk()) EidosValue_Float_vector())->resize_no_initialize((int)num_probs);
+		result_SP = EidosValue_SP(float_result);
+		
+		for (int value_index = 0; value_index < num_probs; ++value_index)
+		{
+			double mu = (mu_singleton ? mu0 : arg_mu->FloatAtIndex(value_index, nullptr));
+			double sigma = (sigma_singleton ? sigma0 : arg_sigma->FloatAtIndex(value_index, nullptr));
+		  if (float_data[value_index] < 0.0 || float_data[value_index] > 1.0)
+				EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires 0.0 <= p <= 1.0 (" << EidosStringForFloat(float_data[value_index]) << " supplied)." << EidosTerminate(nullptr);
+			
+			if (sigma <= 0.0)
+				EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_qnorm): function qnorm() requires sd > 0.0 (" << EidosStringForFloat(sigma) << " supplied)." << EidosTerminate(nullptr);
+			
+			float_result->set_float_no_check(gsl_cdf_gaussian_Pinv(float_data[value_index], sigma) + mu, value_index);
+		}
+	}
+	
+	return result_SP;
+}
+
 
 //	(float)pnorm(float q, [numeric mean = 0], [numeric sd = 1])
 EidosValue_SP Eidos_ExecuteFunction_pnorm(const EidosValue_SP *const p_arguments, __attribute__((unused)) int p_argument_count, __attribute__((unused)) EidosInterpreter &p_interpreter)

--- a/eidos/eidos_functions.h
+++ b/eidos/eidos_functions.h
@@ -101,6 +101,7 @@ EidosValue_SP Eidos_ExecuteFunction_var(const EidosValue_SP *const p_arguments, 
 //	distribution draw / density functions
 EidosValue_SP Eidos_ExecuteFunction_dmvnorm(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_dnorm(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);
+EidosValue_SP Eidos_ExecuteFunction_qnorm(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_pnorm(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_rbeta(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_rbinom(const EidosValue_SP *const p_arguments, int p_argument_count, EidosInterpreter &p_interpreter);

--- a/eidos/eidos_test.cpp
+++ b/eidos/eidos_test.cpp
@@ -5241,7 +5241,28 @@ void _RunFunctionDistributionTests(void)
 	EidosAssertScriptRaise("dnorm(1.0, c(-10, 10, 1), 100.0);", 0, "requires mean to be");
 	EidosAssertScriptRaise("dnorm(1.0, 10.0, c(0.1, 10, 1));", 0, "requires sd to be");
 	EidosAssertScriptSuccess("dnorm(NAN);", gStaticEidosValue_FloatNAN);
+		
+	// qnorm()
+	EidosAssertScriptSuccess("-qnorm(0.0);", gStaticEidosValue_FloatINF);
+	EidosAssertScriptSuccess("qnorm(1.0);", gStaticEidosValue_FloatINF);
+	EidosAssertScriptSuccess("qnorm(0.05) + 1.644854 < 0.00001 ;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true}));
+	EidosAssertScriptSuccess("qnorm(0.95) - 1.644854 < 0.00001 ;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true}));
+	EidosAssertScriptSuccess("qnorm(0.05, 0, 1) + 1.644854 < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true}));
+	EidosAssertScriptSuccess("qnorm(0.05, 5.5, 3.4) + 0.09250233 < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true}));
+	EidosAssertScriptSuccess("qnorm(0.05, 0, 1.0) + 1.644854 < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true}));
+	EidosAssertScriptSuccess("qnorm(c(0.05,0.05), c(0, 0), 1) + 1.644854 < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true, true}));
+	EidosAssertScriptSuccess("c(2, 1)*qnorm(c(0.05, 0.05), 0., c(1, 2)) + 3.289707 < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true, true}));
+	EidosAssertScriptSuccess("qnorm(c(0.25, 0.5, 0.75)) - c(-0.6744898, 0.0000000, 0.6744898) < 0.00001;", EidosValue_SP(new (gEidosValuePool->AllocateChunk()) EidosValue_Logical{true, true, true}));
+	EidosAssertScriptRaise("qnorm(0.5, 0, 0);", 0, "requires sd > 0.0");
+	EidosAssertScriptRaise("qnorm(-0.1);", 0, "requires 0.0 <= p <= 1.0");
+	EidosAssertScriptRaise("qnorm(1.1);", 0, "requires 0.0 <= p <= 1.0");
+	EidosAssertScriptRaise("qnorm(c(0.05, 1.1));", 0, "requires 0.0 <= p <= 1.0");
+	EidosAssertScriptRaise("qnorm(c(0.05, 0.95), 0.0, c(5, -1.0));", 0, "requires sd > 0.0");
+	EidosAssertScriptRaise("qnorm(0.1, c(-10, 10, 1), 100.0);", 0, "requires mean to be");
+	EidosAssertScriptRaise("qnorm(0.1, 10.0, c(0.1, 10, 1));", 0, "requires sd to be");
+	EidosAssertScriptSuccess("qnorm(NAN);", gStaticEidosValue_FloatNAN);
 	
+
 	// pnorm()
 	EidosAssertScriptSuccess("pnorm(float(0));", gStaticEidosValue_Float_ZeroVec);
 	EidosAssertScriptSuccess("pnorm(float(0), float(0), float(0));", gStaticEidosValue_Float_ZeroVec);

--- a/gsl/cdf/gaussinv.c
+++ b/gsl/cdf/gaussinv.c
@@ -1,0 +1,202 @@
+/* cdf/inverse_normal.c
+ *
+ * Copyright (C) 2002 Przemyslaw Sliwa and Jason H. Stover.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/*
+ * Computes the inverse normal cumulative distribution function 
+ * according to the algorithm shown in 
+ *
+ *      Wichura, M.J. (1988).
+ *      Algorithm AS 241: The Percentage Points of the Normal Distribution.
+ *      Applied Statistics, 37, 477-484.
+ */
+
+#include <config.h>
+#include "gsl_errno.h"
+#include "gsl_math.h"
+#include "gsl_cdf.h"
+
+#include "rat_eval.h"
+
+static double
+small (double q)
+{
+  const double a[8] = { 3.387132872796366608, 133.14166789178437745,
+    1971.5909503065514427, 13731.693765509461125,
+    45921.953931549871457, 67265.770927008700853,
+    33430.575583588128105, 2509.0809287301226727
+  };
+
+  const double b[8] = { 1.0, 42.313330701600911252,
+    687.1870074920579083, 5394.1960214247511077,
+    21213.794301586595867, 39307.89580009271061,
+    28729.085735721942674, 5226.495278852854561
+  };
+
+  double r = 0.180625 - q * q;
+
+  double x = q * rat_eval (a, 8, b, 8, r);
+
+  return x;
+}
+
+static double
+intermediate (double r)
+{
+  const double a[] = { 1.42343711074968357734, 4.6303378461565452959,
+    5.7694972214606914055, 3.64784832476320460504,
+    1.27045825245236838258, 0.24178072517745061177,
+    0.0227238449892691845833, 7.7454501427834140764e-4
+  };
+
+  const double b[] = { 1.0, 2.05319162663775882187,
+    1.6763848301838038494, 0.68976733498510000455,
+    0.14810397642748007459, 0.0151986665636164571966,
+    5.475938084995344946e-4, 1.05075007164441684324e-9
+  };
+
+  double x = rat_eval (a, 8, b, 8, (r - 1.6));
+
+  return x;
+}
+
+static double
+tail (double r)
+{
+  const double a[] = { 6.6579046435011037772, 5.4637849111641143699,
+    1.7848265399172913358, 0.29656057182850489123,
+    0.026532189526576123093, 0.0012426609473880784386,
+    2.71155556874348757815e-5, 2.01033439929228813265e-7
+  };
+
+  const double b[] = { 1.0, 0.59983220655588793769,
+    0.13692988092273580531, 0.0148753612908506148525,
+    7.868691311456132591e-4, 1.8463183175100546818e-5,
+    1.4215117583164458887e-7, 2.04426310338993978564e-15
+  };
+
+  double x = rat_eval (a, 8, b, 8, (r - 5.0));
+
+  return x;
+}
+
+double
+gsl_cdf_ugaussian_Pinv (const double P)
+{
+  double r, x, pp;
+
+  double dP = P - 0.5;
+
+  if (P == 1.0)
+    {
+      return GSL_POSINF;
+    }
+  else if (P == 0.0)
+    {
+      return GSL_NEGINF;
+    }
+
+  if (fabs (dP) <= 0.425)
+    {
+      x = small (dP);
+
+      return x;
+    }
+
+  pp = (P < 0.5) ? P : 1.0 - P;
+
+  r = sqrt (-log (pp));
+
+  if (r <= 5.0)
+    {
+      x = intermediate (r);
+    }
+  else
+    {
+      x = tail (r);
+    }
+
+  if (P < 0.5)
+    {
+      return -x;
+    }
+  else
+    {
+      return x;
+    }
+
+}
+
+double
+gsl_cdf_ugaussian_Qinv (const double Q)
+{
+  double r, x, pp;
+
+  double dQ = Q - 0.5;
+
+  if (Q == 1.0)
+    {
+      return GSL_NEGINF;
+    }
+  else if (Q == 0.0)
+    {
+      return GSL_POSINF;
+    }
+
+  if (fabs (dQ) <= 0.425)
+    {
+      x = small (dQ);
+
+      return -x;
+    }
+
+  pp = (Q < 0.5) ? Q : 1.0 - Q;
+
+  r = sqrt (-log (pp));
+
+  if (r <= 5.0)
+    {
+      x = intermediate (r);
+    }
+  else
+    {
+      x = tail (r);
+    }
+
+  if (Q < 0.5)
+    {
+      return x;
+    }
+  else
+    {
+      return -x;
+    }
+}
+
+
+double
+gsl_cdf_gaussian_Pinv (const double P, const double sigma)
+{
+  return sigma * gsl_cdf_ugaussian_Pinv (P);
+}
+
+double
+gsl_cdf_gaussian_Qinv (const double Q, const double sigma)
+{
+  return sigma * gsl_cdf_ugaussian_Qinv (Q);
+}

--- a/gsl/cdf/rat_eval.h
+++ b/gsl/cdf/rat_eval.h
@@ -1,0 +1,25 @@
+static double
+rat_eval (const double a[], const size_t na,
+          const double b[], const size_t nb, const double x)
+{
+  size_t i, j;
+  double u, v, r;
+
+  u = a[na - 1];
+
+  for (i = na - 1; i > 0; i--)
+    {
+      u = x * u + a[i - 1];
+    }
+
+  v = b[nb - 1];
+
+  for (j = nb - 1; j > 0; j--)
+    {
+      v = x * v + b[j - 1];
+    }
+
+  r = u / v;
+
+  return r;
+}


### PR DESCRIPTION
Here is a draft pull request of the Eidos `qnorm()` function. Specifically, it

- Adds the necessary GSL code to use its function `gsl_cdf_gaussian_Pinv()`.
- Implements an Eidos version of qnorm(), that is vectorized like dnorm().
- Adds tests including exception testing.

The function works as expected as far as I can tell. I want to confirm you agree (1) the unit tests look sufficient (true values calculated against R's `qnorm()`) and (2) the exception handling for probabilities out of bounds look good. 

I'll begin working on documentation I can send your way in a bit. 