### PR TITLE
Add missing includes needed to build with Qt 5.14.1

### DIFF
--- a/QtSLiM/QtSLiMChromosomeWidget.cpp
+++ b/QtSLiM/QtSLiMChromosomeWidget.cpp
@@ -26,6 +26,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QtDebug>
+#include <QMouseEvent>
 
 
 // OpenGL constants

--- a/QtSLiM/QtSLiMGraphView.cpp
+++ b/QtSLiM/QtSLiMGraphView.cpp
@@ -31,6 +31,7 @@
 #include <QPdfWriter>
 #include <QBuffer>
 #include <QDebug>
+#include <QtGui>
 
 
 QFont QtSLiMGraphView::labelFontOfPointSize(double size)

--- a/QtSLiM/QtSLiMIndividualsWidget.cpp
+++ b/QtSLiM/QtSLiMIndividualsWidget.cpp
@@ -24,6 +24,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QDebug>
+#include <QtGui>
 
 
 // OpenGL constants

--- a/QtSLiM/QtSLiMTablesDrawer.cpp
+++ b/QtSLiM/QtSLiMTablesDrawer.cpp
@@ -23,6 +23,7 @@
 
 #include <QPainter>
 #include <QDebug>
+#include <QKeyEvent>
 
 #include "QtSLiMWindow.h"
 


### PR DESCRIPTION
Hey @bhaller, I needed to add a few includes to avoid "incomplete type" compiler errors on Arch linux with Qt 5.14.1.