### PR TITLE
add missing #include

### DIFF
--- a/QtSLiM/QtSLiMGraphView_SubpopFitnessDists.cpp
+++ b/QtSLiM/QtSLiMGraphView_SubpopFitnessDists.cpp
@@ -25,6 +25,7 @@
 #include "subpopulation.h"
 #include "individual.h"
 
+#include <QPainterPath>
 
 QtSLiMGraphView_SubpopFitnessDists::QtSLiMGraphView_SubpopFitnessDists(QWidget *parent, QtSLiMWindow *controller) : QtSLiMGraphView(parent, controller)
 {


### PR DESCRIPTION
Build error with Qt-5.15.0 is:

/home/grg/aur/slim-simulator/src/SLiM/QtSLiM/QtSLiMGraphView_SubpopFitnessDists.cpp: In member function ‘virtual void QtSLiMGraphView_SubpopFitnessDists::drawGraph(QPainter&, QRect)’:
/home/grg/aur/slim-simulator/src/SLiM/QtSLiM/QtSLiMGraphView_SubpopFitnessDists.cpp:138:26: error: aggregate ‘QPainterPath linePath’ has incomplete type and cannot be defined
  138 |             QPainterPath linePath;
      |                          ^~~~~~~~
/home/grg/aur/slim-simulator/src/SLiM/QtSLiM/QtSLiMGraphView_SubpopFitnessDists.cpp:160:18: error: aggregate ‘QPainterPath linePath’ has incomplete type and cannot be defined
  160 |     QPainterPath linePath;
      |                  ^~~~~~~~