### PR TITLE
update to tskit C_0.99.6

### DIFF
--- a/treerec/_README
+++ b/treerec/_README
@@ -19,11 +19,12 @@ Simplification interval:
 - `CheckAutoSimplification` :
 
 
-The code in `tskit/` is from [tskit/lib](https://github.com/tskit-dev/msprime/tree/master/lib), release `C_0.99.5`.
+The code in `tskit/` is from [tskit/lib](https://github.com/tskit-dev/msprime/tree/master/lib), release `C_0.99.6`.
 
 The code in `tskit/kastore` is from [kastore/c](https://github.com/tskit-dev/kastore/tree/master/c), release `0.3.0`.
 
 **Changelog:**
 
+- *5 September 2020*: updated to tskit C_0.99.5
 - *27 August 2020*: updated to tskit C_0.99.5
 - *12 August 2020*: updated to tskit C_0.99.4 and kastore 0.3.0.

--- a/treerec/tskit/core.h
+++ b/treerec/tskit/core.h
@@ -128,7 +128,7 @@ to the API or ABI are introduced, i.e., the addition of a new function.
 The library patch version. Incremented when any changes not relevant to the
 to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 */
-#define TSK_VERSION_PATCH   5
+#define TSK_VERSION_PATCH   6
 /** @} */
 
 /* Node flags */


### PR DESCRIPTION
The only substantial change is to fix the bug in simplify(keep_input_roots). This passes my tests.