### PR TITLE
Change initializeTreeSequence to initializeTreeSeq

### DIFF
--- a/EidosScribe/EidosTextView.mm
+++ b/EidosScribe/EidosTextView.mm
@@ -2031,7 +2031,7 @@
 			[completions addObject:candidate];
 	}
 #else
-	// This is part-based completion, where iTr will complete to initializeTreeSequence() and iGTy
+	// This is part-based completion, where iTr will complete to initializeTreeSeq() and iGTy
 	// will complete to initializeGenomicElementType().  To do this, we use a special comparator
 	// that returns a score for the quality of the match, and then we sort all matches by score.
 	std::vector<int64_t> scores;

--- a/QtSLiM/QtSLiMScriptTextEdit.cpp
+++ b/QtSLiM/QtSLiMScriptTextEdit.cpp
@@ -1562,7 +1562,7 @@ QStringList QtSLiMTextEdit::completionsFromArrayMatchingBase(QStringList candida
 			completions << candidate;
 	}
 #else
-	// This is part-based completion, where iTr will complete to initializeTreeSequence() and iGTy
+	// This is part-based completion, where iTr will complete to initializeTreeSeq() and iGTy
 	// will complete to initializeGenomicElementType().  To do this, we use a special comparator
 	// that returns a score for the quality of the match, and then we sort all matches by score.
 	std::vector<int64_t> scores;

--- a/treerec/tests/README
+++ b/treerec/tests/README
@@ -7,7 +7,7 @@ To add a new test:
         ```
         source("testing_utils.slim");
         ```
-        in `initialize()` (this calls `InitializeTreeSequence()` and defines functions);
+        in `initialize()` (this calls `initializeTreeSeq()` and defines functions);
         and then call
         ```
         outputMutationResult();


### PR DESCRIPTION
I think that in the docs/etc sometimes the wrong function name is used. From my reading it should be `initializeTreeSeq()` (small "i", no "ence" at the end).