### PR TITLE
Use new tskit param

### DIFF
--- a/treerec/tests/test_mutation_output.py
+++ b/treerec/tests/test_mutation_output.py
@@ -67,7 +67,7 @@ class TestWithMutations(TestSlimOutput):
             #  indexed by position, then SLiM ID
             slim = self.read_test_mutation_output(filename="test_output/slim_mutation_output.txt")
             pos = -1
-            for var in ts.variants(impute_missing_data=True):
+            for var in ts.variants(isolated_as_missing=False):
                 pos += 1
                 while pos < int(var.position):
                     # invariant sites: no genotypes


### PR DESCRIPTION
To avoid warning issued as of tskit 0.3: "FutureWarning: The impute_missing_data parameter was deprecated in 0.3.0 and will be removed. Use ``isolated_as_missing=False`` instead of``impute_missing_data=True``"

Do we need to also specify a minimum tskit version of (say) 0.3.4 somewhere @petrelharp ?