### PR TITLE
switch from nose to pytest, closes #134

### DIFF
--- a/treerec/tests/do_test.sh
+++ b/treerec/tests/do_test.sh
@@ -33,14 +33,14 @@ do
     if [ -e "test_output/slim_no_mutation_output.txt" ]
     then
         echo "  Testing no-mutation output."
-        python3 -m nose test_no_mutation_output.py || exit 1
+        python3 -m pytest test_no_mutation_output.py || exit 1
         TESTED="yes"
     fi
 
     if [ -e "test_output/slim_mutation_output.txt" ]
     then
         echo "  Testing with-mutation output."
-        python3 -m nose test_mutation_output.py || exit 1
+        python3 -m pytest test_mutation_output.py || exit 1
         TESTED="yes"
     fi
 

--- a/treerec/tests/test_mutation_output.py
+++ b/treerec/tests/test_mutation_output.py
@@ -12,13 +12,13 @@ class TestWithMutations(TestSlimOutput):
         slim = {}
         for header in slim_file:
             headstring = header.split()
-            self.assertEqual(headstring[0], "#Genome:")
+            assert headstring[0] == "#Genome:"
             genome = int(headstring[1])
             mutations = slim_file.readline().split()
-            self.assertEqual(mutations[0], "Mutations:")
+            assert mutations[0] == "Mutations:"
             mutations = [int(u) for u in mutations[1:]]
             positions = slim_file.readline().split()
-            self.assertEqual(positions[0], "Positions:")
+            assert positions[0] == "Positions:"
             positions = [int(u) for u in positions[1:]]
             for pos, mut in zip(positions, mutations):
                 if pos not in slim:
@@ -67,11 +67,11 @@ class TestWithMutations(TestSlimOutput):
             #  indexed by position, then SLiM ID
             slim = self.read_test_mutation_output(filename="test_output/slim_mutation_output.txt")
             pos = -1
-            for var in ts.variants(impute_missing_data=True):
+            for var in ts.variants(isolated_as_missing=False):
                 pos += 1
                 while pos < int(var.position):
                     # invariant sites: no genotypes
-                    self.assertTrue(pos not in slim)
+                    assert pos not in slim
                     pos += 1
                 print("-----------------")
                 print("pos:", pos)
@@ -85,8 +85,8 @@ class TestWithMutations(TestSlimOutput):
                         print("msp:", msp_genotypes)
                         if (pos not in slim) or (j not in slim[pos]):
                             # no mutations at this site
-                            self.assertEqual(msp_genotypes, [''])
+                            assert msp_genotypes == ['']
                         else:
                             print("slim:", slim[pos][j])
-                            self.assertEqual(set(msp_genotypes), set([str(x) for x in slim[pos][j]]))
+                            assert set(msp_genotypes) == set([str(x) for x in slim[pos][j]])
 

--- a/treerec/tests/test_no_mutation_output.py
+++ b/treerec/tests/test_no_mutation_output.py
@@ -10,14 +10,14 @@ class TestNoMutations(TestSlimOutput):
             slim_file = open(filename, "r")
             slim = []
             for header in slim_file:
-                self.assertEqual(header[0:12], "MutationType")
+                assert header[0:12] == "MutationType"
                 mut, pos = header[12:].split()
                 pos = int(pos)
                 if pos == len(slim):
                     slim.append({})
                 slim_ids = [int(u) for u in slim_file.readline().split()]
                 for u in slim_ids:
-                    self.assertTrue(u in ids)
+                    assert u in ids
                 slim[pos][mut] = [ids[u] for u in slim_ids]
             return slim
 
@@ -50,13 +50,13 @@ class TestNoMutations(TestSlimOutput):
             if len(y[a]) > 0:
                 a_labels = []
                 for u in y[a]:
-                    self.assertTrue(u in x)
-                    self.assertTrue(u not in all_ids)
+                    assert u in x
+                    assert u not in all_ids
                     all_ids.append(u)
                     a_labels.append(x[u])
                 print('IDs sharing mutation', a, ":", y[a])
                 print('labels of roots in from tree:', a_labels)
-                self.assertEqual(len(set(a_labels)), 1)
+                assert len(set(a_labels)) == 1
 
     def test_ts_slim_consistency(self):
         # load tree sequence

--- a/treerec/tests/testutils/__init__.py
+++ b/treerec/tests/testutils/__init__.py
@@ -1,8 +1,7 @@
 import pyslim
 import msprime
-import unittest
 
-class TestSlimOutput(unittest.TestCase):
+class TestSlimOutput:
 
     def get_slim_ids(self, ts):
         # get SLiM ID -> msprime ID map from metadata


### PR DESCRIPTION
This does the (easy) job of switching to pytest (and I also incorporated #135 before I noticed you'd done that). Clearly the how we run the tests could be improved (eg parallelization) but I'm not going to jump into that at the moment. Note that these are supplemental tests, which just check for consistency between the tree sequence and what SLiM says is going on, to @bhaller's much more comprehensive set of tests.