### PR TITLE
Activate "keep unary in individuals"

### DIFF
--- a/core/slim_sim.cpp
+++ b/core/slim_sim.cpp
@@ -5043,7 +5043,9 @@ void SLiMSim::SimplifyTreeSequence(void)
 	if (ret < 0) handle_error("tsk_table_collection_deduplicate_sites", ret);
 	
 	// simplify
-	ret = tsk_table_collection_simplify(&tables_, samples.data(), (tsk_size_t)samples.size(), TSK_FILTER_SITES | TSK_FILTER_INDIVIDUALS | TSK_KEEP_INPUT_ROOTS, NULL);
+	flags = TSK_FILTER_SITES | TSK_FILTER_INDIVIDUALS | TSK_KEEP_INPUT_ROOTS;
+	if (!retain_coalescent_only_) flags |= TSK_KEEP_UNARY;
+	ret = tsk_table_collection_simplify(&tables_, samples.data(), (tsk_size_t)samples.size(), flags, NULL);
 	if (ret != 0) handle_error("tsk_table_collection_simplify", ret);
 	
 	// update map of remembered_genomes_, which are now the first n entries in the node table
@@ -7349,7 +7351,7 @@ void SLiMSim::CrosscheckTreeSeqIntegrity(void)
 				for (Genome *genome : iter.second->parent_genomes_)
 					samples.push_back(genome->tsk_node_id_);
 			
-			int flags = TSK_NO_CHECK_INTEGRITY;
+			tsk_flags_t flags = TSK_NO_CHECK_INTEGRITY;
 #if DEBUG
 			flags = 0;
 #endif
@@ -7359,7 +7361,9 @@ void SLiMSim::CrosscheckTreeSeqIntegrity(void)
 			ret = tsk_table_collection_deduplicate_sites(tables_copy, 0);
 			if (ret < 0) handle_error("tsk_table_collection_deduplicate_sites", ret);
 			
-			ret = tsk_table_collection_simplify(tables_copy, samples.data(), (tsk_size_t)samples.size(), TSK_FILTER_SITES | TSK_FILTER_INDIVIDUALS | TSK_KEEP_INPUT_ROOTS, NULL);
+        	flags = TSK_FILTER_SITES | TSK_FILTER_INDIVIDUALS | TSK_KEEP_INPUT_ROOTS;
+        	if (!retain_coalescent_only_) flags |= TSK_KEEP_UNARY;
+			ret = tsk_table_collection_simplify(tables_copy, samples.data(), (tsk_size_t)samples.size(), flags, NULL);
 			if (ret != 0) handle_error("tsk_table_collection_simplify", ret);
 			
 		// must build indexes before compute mutation parents

--- a/treerec/tests/conftest.py
+++ b/treerec/tests/conftest.py
@@ -135,11 +135,12 @@ class OutputResult:
             fields = line.split()
             assert fields[0].startswith("#Individual:")
             store = fields[0][len("#Individual:"):]
-            assert store in ("remember", "retain", "output")
+            assert store in ("remember", "retain", "retain_if_unary", "output")
             pedigree_id = int(fields[1])
-            if pedigree_id in slim and store == "retain":
-                # We have a duplicate: "remember"ed takes priority
-                continue
+            if pedigree_id in slim:
+                # We have a duplicate:
+                if slim[pedigree_id].type == "remember":
+                    continue  # "remember"ed takes priority: do not overwrite
             slim[pedigree_id] = SLiMindividual(
                 type=store,
                 population=int(fields[2]),
@@ -166,7 +167,7 @@ def run_slim(recipe, run_dir, recipe_dir="test_recipes"):
     these directories, which contain the files on which tests should be run
     """
     script_dir = os.path.dirname(os.path.realpath(__file__))  # Path to this file
-    full_recipe = os.path.abspath(os.path.join(recipe_dir, recipe))
+    full_recipe = os.path.abspath(os.path.join(script_dir, recipe_dir, recipe))
     assert os.path.isdir(run_dir)  # should have been created by caller
     cmd = ["slim", "-s", "22", "-d", f"RUN_DIR=\"{run_dir}\"", full_recipe]
     print(f"Running {cmd} in dir '{run_dir}', errors etc to 'SLiM_run_output.log'")

--- a/treerec/tests/recipe_specs.py
+++ b/treerec/tests/recipe_specs.py
@@ -2,17 +2,19 @@
 
 import os
 
-# possible attributes to simulation scripts are
+# Possible attributes to simulation scripts are
 #  mutations/marked_mutations: does the recipe source init.slim or init_marked_mutations.slim? 
 #  individuals: records individuals 
-# All files are of the form `tests/test_recipes/{key}`
+#
+# All files are of the form `tests/test_recipes/{key}`. By convention a name like
+# test_002_xxx is based on the corresponding SLiM test recipe
 recipe_specs = {
-    "test_000_ancestral_marks.slim":	      {"marked_mutations": True},
-    "test_000_ongoing_muts.slim":		      {"marked_mutations": True},
-    "test_000_sexual_WF.slim":		          {"marked_mutations": True},
-    "test_000_sexual_nonwf.slim":		      {"mutations": True},
-    "test_000_simple_nonwf.slim":		      {"mutations": True},
-    "test_000_withdraw_indivs.slim":	      {"mutations": True},
+    "test_____ancestral_marks.slim":	      {"marked_mutations": True},
+    "test_____ongoing_muts.slim":		      {"marked_mutations": True},
+    "test_____sexual_WF.slim":		          {"marked_mutations": True},
+    "test_____sexual_nonwf.slim":		      {"mutations": True},
+    "test_____simple_nonwf.slim":		      {"mutations": True},
+    "test_____withdraw_indivs.slim":	      {"mutations": True},
     "test_002_quick_neutral.slim":	          {"marked_mutations": True},
     "test_004 simple sexual A.slim":	      {"mutations": True},
     "test_005 simple sexual X.slim":	      {"mutations": True},
@@ -26,9 +28,11 @@ recipe_specs = {
     "test_039 pure selfing.slim":             {"mutations": True},
     "test_040 pure cloning sexual.slim":      {"mutations": True},
     "test_042 haploid clonals.slim":          {"mutations": True},
-    "test_050_remember_individuals.slim":     {"marked_mutations": True, "individuals": True},
-    "test_051_retain_individuals.slim":       {"marked_mutations": True, "individuals": True},
-    "test_052_retain_individuals_nonWF.slim": {"marked_mutations": True, "individuals": True},
+    "test_____remember_individuals.slim":     {"marked_mutations": True, "individuals": True},
+    "test_____retain_individuals_nonWF.slim": {"marked_mutations": True, "individuals": True},
+    "test_____retain_individuals_unary.slim": {"marked_mutations": True, "individuals": True},
+    "test_____retain_and_remember_individuals.slim": {"marked_mutations": True, "individuals": True},
+    "test_____retain_individuals_nonWF_unary.slim": {"marked_mutations": True, "individuals": True},
     "test_097 modeling nucleotides.slim":     {"mutations": True},
 }
 

--- a/treerec/tests/test_consistency.py
+++ b/treerec/tests/test_consistency.py
@@ -103,7 +103,7 @@ class TestIndividuals:
                 alive = {ts.individual(i).metadata['pedigree_id'] for i in ts.individuals_alive_at(0)}
                 num_expected = 0
                 for ped_id, slim_ind in slim_individuals.items():
-                    if slim_ind.type == "retain":
+                    if slim_ind.type.startswith("retain"):
                         # retained individuals should only be present in the TS if they
                         # have genomic material. We should check which have nodes that exist
                         ts_nodes = [ids[n] for n in slim_ind.nodes if n in ids]
@@ -118,7 +118,7 @@ class TestIndividuals:
                                 assert not ts.node(n).is_sample()
                         else:
                             assert ped_id not in ts_individuals
-                    else:
+                    elif slim_ind.type=="remember":
                         # permanently "remember"ed individuals and ones that exist during ts
                         # output are always present, and their nodes should be marked as
                         # as samples
@@ -133,4 +133,7 @@ class TestIndividuals:
                             assert ts.node(n).is_sample()
                         if ped_id not in alive:
                             assert slim_ind.type == "remember"
+                    elif slim_ind.type=="output":
+                        num_expected += 1
+                        
                 assert num_expected == ts.num_individuals

--- a/treerec/tests/test_recipes/test_____ancestral_marks.slim
+++ b/treerec/tests/test_recipes/test_____ancestral_marks.slim
@@ -1,0 +1,40 @@
+initialize() {
+
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+
+	// TREE SEQUENCE TEST OUTPUT
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+
+	defineConstant("K",30);  
+
+	initializeGenomicElementType("g1",m1,1.0);
+	initializeGenomicElement(g1, 0, 99);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.1);
+}
+
+reproduction() {
+	subpop.addCrossed(individual,subpop.sampleIndividuals(1));
+}
+1 early() {
+	sim.addSubpop("p1",10);
+}   
+
+1 early() {
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount;
+}
+
+10 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____ongoing_muts.slim
+++ b/treerec/tests/test_recipes/test_____ongoing_muts.slim
@@ -1,0 +1,40 @@
+initialize() {
+
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+
+	// TREE SEQUENCE TEST OUTPUT
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+
+	defineConstant("K",8);  
+
+	initializeGenomicElementType("g1",m1,1.0);
+	initializeGenomicElement(g1, 0, 99);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.1);
+}
+
+reproduction() {
+	subpop.addCrossed(individual,subpop.sampleIndividuals(1));
+}
+1 early() {
+	sim.addSubpop("p1",100);
+}   
+
+1 early() {
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount;
+}
+
+200 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____remember_individuals.slim
+++ b/treerec/tests/test_recipes/test_____remember_individuals.slim
@@ -1,0 +1,46 @@
+// A test script to check that remembered individuals are output in the TS
+// uses a modified version of the standard continuous space recipe, so that
+// we can check on the x,y position of individuals.
+
+initialize() {
+	initializeSLiMOptions(keepPedigrees=T, dimensionality="xy");
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);
+}
+1 {
+	sim.addSubpop("p1", 500);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+1 late() {
+	// initial positions are random in ([0,1], [0,1])
+	p1.individuals.x = runif(p1.individualCount);
+	p1.individuals.y = runif(p1.individualCount);
+}
+modifyChild() {
+	// draw a child position near the first parent, within bounds
+	do child.x = parent1.x + rnorm(1, 0, 0.02);
+	while ((child.x < 0.0) | (child.x > 1.0));
+	
+	do child.y = parent1.y + rnorm(1, 0, 0.02);
+	while ((child.y < 0.0) | (child.y > 1.0));
+	
+	return T;
+}
+
+50 late() {
+	// permanently remember the first 5 individuals
+	sim.treeSeqRememberIndividuals(p1.individuals[1:5], permanent=T);
+	addIndividuals(p1.individuals[1:5]);
+}
+
+200 late() {
+	outputIndividuals();
+	outputMutationResult();
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____retain_and_remember_individuals.slim
+++ b/treerec/tests/test_recipes/test_____retain_and_remember_individuals.slim
@@ -1,0 +1,55 @@
+// A test script to check that some retained individuals are output in the TS
+// uses a modified version of the standard continuous space recipe, so that
+// we can check on the x,y position of individuals.
+
+initialize() {
+	initializeSLiMOptions(keepPedigrees=T, dimensionality="xy");
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);	
+}
+1 {
+	sim.addSubpop("p1", 500);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+1 late() {
+	// initial positions are random in ([0,1], [0,1])
+	p1.individuals.x = runif(p1.individualCount);
+	p1.individuals.y = runif(p1.individualCount);
+}
+modifyChild() {
+	// draw a child position near the first parent, within bounds
+	do child.x = parent1.x + rnorm(1, 0, 0.02);
+	while ((child.x < 0.0) | (child.x > 1.0));
+	
+	do child.y = parent1.y + rnorm(1, 0, 0.02);
+	while ((child.y < 0.0) | (child.y > 1.0));
+	
+	return T;
+}
+
+50 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain");
+}
+
+100 late() {
+	// also retain all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain");
+	// but also remember a few of them
+	sim.treeSeqRememberIndividuals(p1.individuals[1:5]);
+	addIndividuals(p1.individuals[1:5], "remember");
+}
+
+200 late() {
+	outputIndividuals();
+	outputMutationResult();
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____retain_individuals_nonWF.slim
+++ b/treerec/tests/test_recipes/test_____retain_individuals_nonWF.slim
@@ -1,0 +1,63 @@
+// A test script to check that some retained individuals are output in the TS
+// uses a modified version of the standard continuous space recipe, so that
+// we can check on the x,y position of individuals.
+
+initialize() {
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T, dimensionality="xy");
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);	
+	defineConstant("K", 500); //carrying capacity for global density dependence
+}
+
+reproduction() {
+	subpop.addCrossed(individual, subpop.sampleIndividuals(1)); //random mating
+}
+
+1 {
+	sim.addSubpop("p1", 500);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount; //scale fitness (so that some individuals die when number of individuals is greater than K)
+}
+
+1 late() {
+	// initial positions are random in ([0,1], [0,1])
+	p1.individuals.x = runif(p1.individualCount);
+	p1.individuals.y = runif(p1.individualCount);
+}
+modifyChild() {
+	// draw a child position near the first parent, within bounds
+	do child.x = parent1.x + rnorm(1, 0, 0.02);
+	while ((child.x < 0.0) | (child.x > 1.0));
+	
+	do child.y = parent1.y + rnorm(1, 0, 0.02);
+	while ((child.y < 0.0) | (child.y > 1.0));
+	
+	return T;
+}
+
+50 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain");
+}
+
+100 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain");
+}
+
+200 late() {
+	outputIndividuals();
+	outputMutationResult();
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____retain_individuals_nonWF_unary.slim
+++ b/treerec/tests/test_recipes/test_____retain_individuals_nonWF_unary.slim
@@ -1,0 +1,63 @@
+// A test script to check that some retained individuals are output in the TS
+// uses a modified version of the standard continuous space recipe, so that
+// we can check on the x,y position of individuals.
+
+initialize() {
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T, dimensionality="xy");
+	source("init_marked_mutations.slim");
+    initializeTreeSeq(retainCoalescentOnly=F);
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);	
+	defineConstant("K", 500); //carrying capacity for global density dependence
+}
+
+reproduction() {
+	subpop.addCrossed(individual, subpop.sampleIndividuals(1)); //random mating
+}
+
+1 {
+	sim.addSubpop("p1", 500);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount; //scale fitness (so that some individuals die when number of individuals is greater than K)
+}
+
+1 late() {
+	// initial positions are random in ([0,1], [0,1])
+	p1.individuals.x = runif(p1.individualCount);
+	p1.individuals.y = runif(p1.individualCount);
+}
+modifyChild() {
+	// draw a child position near the first parent, within bounds
+	do child.x = parent1.x + rnorm(1, 0, 0.02);
+	while ((child.x < 0.0) | (child.x > 1.0));
+	
+	do child.y = parent1.y + rnorm(1, 0, 0.02);
+	while ((child.y < 0.0) | (child.y > 1.0));
+	
+	return T;
+}
+
+10 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain_if_unary");
+}
+
+20 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain_if_unary");
+}
+
+200 late() {
+	outputIndividuals();
+	outputMutationResult();
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____retain_individuals_unary.slim
+++ b/treerec/tests/test_recipes/test_____retain_individuals_unary.slim
@@ -1,0 +1,56 @@
+// A test script to check that some retained individuals are output in the TS
+// uses a modified version of the standard continuous space recipe, so that
+// we can check on the x,y position of individuals.
+
+initialize() {
+	initializeSLiMOptions(keepPedigrees=T, dimensionality="xy");
+	source("init_marked_mutations.slim");
+    initializeTreeSeq(retainCoalescentOnly=F);
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);	
+}
+1 {
+	sim.addSubpop("p1", 500);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);  
+}
+
+1 late() {
+	// initial positions are random in ([0,1], [0,1])
+	//sim.treeSeqRememberIndividuals(p1.individuals[1:2], permanent=T);
+	p1.individuals.x = runif(p1.individualCount);
+	p1.individuals.y = runif(p1.individualCount);
+}
+modifyChild() {
+	// draw a child position near the first parent, within bounds
+	do child.x = parent1.x + rnorm(1, 0, 0.02);
+	while ((child.x < 0.0) | (child.x > 1.0));
+	
+	do child.y = parent1.y + rnorm(1, 0, 0.02);
+	while ((child.y < 0.0) | (child.y > 1.0));
+	
+	return T;
+}
+
+50 late() {
+	// retain but do not permanently remember all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain_if_unary");
+}
+
+100 late() {
+	// also retain all the individuals in this generation
+	sim.treeSeqRememberIndividuals(p1.individuals, permanent=F);
+	addIndividuals(p1.individuals, "retain_if_unary");
+	// but also remember a few of them
+	sim.treeSeqRememberIndividuals(p1.individuals[1:5]);
+	addIndividuals(p1.individuals[1:5], "remember");
+}
+
+200 late() {
+	outputIndividuals();
+	outputMutationResult();
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____sexual_WF.slim
+++ b/treerec/tests/test_recipes/test_____sexual_WF.slim
@@ -1,0 +1,29 @@
+initialize() {
+	// TREE SEQUENCE TEST OUTPUT
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+	source("init_marked_mutations.slim");
+    initializeTreeSeq();
+
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 9);
+	initializeMutationRate(0.0);
+	initializeRecombinationRate(0.2);	
+}
+
+1 late() {
+	sim.addSubpop("p1",10);
+	// TREE SEQUENCE TEST OUTPUT
+	initializeMarks(n_marks);
+}
+
+2 {
+	addAncestralSamples(5);
+}
+
+10 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}

--- a/treerec/tests/test_recipes/test_____sexual_nonwf.slim
+++ b/treerec/tests/test_recipes/test_____sexual_nonwf.slim
@@ -1,0 +1,50 @@
+initialize() {
+
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+	initializeSex('A');
+
+	// TREE SEQUENCE TEST OUTPUT
+	source("init.slim");
+    initializeTreeSeq();
+
+	defineConstant("K",30);  
+
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	m1.mutationStackPolicy = "l";
+	initializeMutationType("m2", 0.5, "f", 0.0);
+	m2.mutationStackPolicy = "s";
+	initializeMutationType("m3", 0.5, "f", 0.0);
+	m3.mutationStackPolicy = "f";
+
+	initializeGenomicElementType("g1",c(m1,m2,m3),c(1.0,1.0,1.0));
+	initializeGenomicElement(g1, 0, 99);
+	initializeMutationRate(0.1);
+	initializeRecombinationRate(0.1);
+}
+
+reproduction(NULL,"F") {
+	subpop.addCrossed(individual,subpop.sampleIndividuals(1, sex="M"));
+}
+1 early() {
+	sim.addSubpop("p1",10);
+	addAncestralSamples(5);
+}   
+
+100 {
+	addAncestralSamples(5);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount;
+}
+
+200 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}
+
+

--- a/treerec/tests/test_recipes/test_____simple_nonwf.slim
+++ b/treerec/tests/test_recipes/test_____simple_nonwf.slim
@@ -1,0 +1,48 @@
+initialize() {
+
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+
+	// TREE SEQUENCE TEST OUTPUT
+	source("init.slim");
+	initializeTreeSeq();
+
+	defineConstant("K",30);  
+
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	m1.mutationStackPolicy = "l";
+	initializeMutationType("m2", 0.5, "f", 0.0);
+	m2.mutationStackPolicy = "s";
+	initializeMutationType("m3", 0.5, "f", 0.0);
+	m3.mutationStackPolicy = "f";
+
+	initializeGenomicElementType("g1",c(m1,m2,m3),c(1.0,1.0,1.0));
+	initializeGenomicElement(g1, 0, 99);
+	initializeMutationRate(0.1);
+	initializeRecombinationRate(0.1);
+}
+
+reproduction() {
+	subpop.addCrossed(individual,subpop.sampleIndividuals(1));
+}
+1 early() {
+	sim.addSubpop("p1",10);
+	addAncestralSamples(5);
+}
+
+100 {
+	addAncestralSamples(5);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount;
+}
+
+200 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}
+

--- a/treerec/tests/test_recipes/test_____withdraw_indivs.slim
+++ b/treerec/tests/test_recipes/test_____withdraw_indivs.slim
@@ -1,0 +1,55 @@
+initialize() {
+
+	initializeSLiMModelType("nonWF");
+	initializeSLiMOptions(keepPedigrees=T); // necessary for pedigreeID
+	initializeSex('A');
+
+	// TREE SEQUENCE TEST OUTPUT
+	source("init.slim");
+    initializeTreeSeq();
+
+	defineConstant("K",30);  
+
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	m1.mutationStackPolicy = "l";
+	initializeMutationType("m2", 0.5, "f", 0.0);
+	m2.mutationStackPolicy = "s";
+	initializeMutationType("m3", 0.5, "f", 0.0);
+	m3.mutationStackPolicy = "f";
+
+	initializeGenomicElementType("g1",c(m1,m2,m3),c(1.0,1.0,1.0));
+	initializeGenomicElement(g1, 0, 99);
+	initializeMutationRate(0.1);
+	initializeRecombinationRate(0.1);
+}
+
+reproduction(NULL,"F") {
+	subpop.addCrossed(individual,subpop.sampleIndividuals(1, sex="M"));
+}
+1 early() {
+	sim.addSubpop("p1",10);
+	addAncestralSamples(5);
+}   
+
+100 {
+	addAncestralSamples(5);
+}
+
+early() {
+	p1.fitnessScaling = K / p1.individualCount;
+}
+
+modifyChild() {
+	// discard half of offspring arbitrarily
+	return (rbinom(1, 1, 0.5) > 0);
+}
+
+200 late() {
+
+	// TREE SEQUENCE TEST OUTPUT
+	outputMutationResult();
+
+	sim.simulationFinished();
+}
+
+

--- a/treerec/tests/test_specific_recipes.py
+++ b/treerec/tests/test_specific_recipes.py
@@ -1,0 +1,138 @@
+"""
+Tests that look at the result of specific recipes in test_recipes
+These may depend on the exact random seed used to run the SLiM simulation.
+Individual recipes can be specified by decorating with
+@pytest.mark.parametrize('recipe', ['test_____my_specific_recipe.slim'], indirect=True)
+"""
+import msprime
+import numpy as np
+import pyslim
+import pytest
+
+from recipe_specs import recipe_eq
+
+
+class TestUnaryNodes:
+
+    def max_children_node(self, ts, exclude_roots=True, exclude_samples=True):
+        """
+        Return a dict mapping nodes to their maximumn # children in the ts
+        """
+
+        max_children = np.zeros(ts.num_nodes, dtype=int)
+        filter = np.zeros(ts.num_nodes, dtype=bool)
+        if exclude_samples:
+            filter[ts.samples()] = True
+        if exclude_roots:
+            filter[np.isin(np.arange(ts.num_nodes), ts.tables.edges.child) == False] = True
+        for tree in ts.trees():
+            for n in tree.nodes():
+                if not ts.node(n).is_sample():
+                    max_children[n] = max(max_children[n], tree.num_children(n))
+        arr = {n:mc for n, (mc, rm) in enumerate(zip(max_children, filter)) if not rm}
+        return arr
+        
+
+    @pytest.mark.parametrize('recipe', indirect=True, argvalues=[
+        "test_____retain_individuals_nonWF_unary.slim",
+        "test_____retain_individuals_unary.slim",
+    ])
+    def test_contains_unary_nonsample_nodes(self, recipe):
+        for result in recipe["results"]:
+            for ts in result.get_ts():
+                assert np.any(np.array(list(self.max_children_node(ts).values())) == 1)
+
+    @pytest.mark.parametrize('recipe', indirect=True, argvalues=[
+        'test_____remember_individuals.slim',
+    ])
+    def test_contains_unary_sample_nodes(self, recipe):
+        """
+        Historical remembered individuals can have a node with a single descendant
+        """
+        for result in recipe["results"]:
+            for ts in result.get_ts():
+                num_unary_nodes = 0
+                for tree in ts.trees():
+                    for n in tree.nodes():
+                        if tree.num_children(n) == 1 and tree.parent(n) >= 0:
+                            assert ts.node(n).individual >= 0  # has an individual
+                            ind = ts.individual(ts.node(n).individual)
+                            assert ts.node(n).is_sample()
+                            assert (ind.flags & pyslim.INDIVIDUAL_REMEMBERED) != 0
+                            num_unary_nodes += 1
+                assert num_unary_nodes > 0
+
+    @pytest.mark.parametrize('recipe', indirect=True, argvalues=[
+        "test_____retain_and_remember_individuals.slim",
+        "test_____retain_individuals_nonWF.slim",
+        "test_____remember_individuals.slim",
+    ])
+    def test_no_purely_unary_internal_nonsample_nodes(self, recipe):
+        for result in recipe["results"]:
+            for ts in result.get_ts():
+                max_children_per_node = self.max_children_node(ts)
+                assert np.all(np.array(list(max_children_per_node.values())) != 1)
+
+
+class TestIndividualsInGeneration:
+    """
+    Test that all the nodes on the ancestry at a fixed set of generations are present
+    """
+    def num_lineages_at_time(self, ts, focal_time, pos):
+        edges = ts.tables.edges
+        times = ts.tables.nodes.time
+        return np.sum(np.logical_and.reduce((
+            times[edges.parent] > focal_time,
+            times[edges.child] <= focal_time,
+            edges.left <= pos,
+            edges.right > pos,
+        )))
+        
+
+    @pytest.mark.parametrize('recipe, gens, final_gen', indirect=["recipe"], argvalues=[
+        ('test_____retain_individuals_unary.slim', (50, 100), 200),
+    ])
+    def test_all_lineages_covered(self, recipe, gens, final_gen):
+        """
+        If all individuals in `gen` are retained with retainCoalescentOnly=F, we should
+        have unary nodes in individuals for all tree sequence lineages
+        """
+        gens = final_gen - np.array(gens)  # convert to ts times
+        for result in recipe["results"]:
+            for ts in result.get_ts():
+                # Check all initial generation nodes are roots
+                nodes_at_start = np.where(ts.tables.nodes.time == final_gen)[0]
+                nodes_at_gen = {g: np.where(ts.tables.nodes.time == g)[0] for g in gens}
+                for nodes in nodes_at_gen.values():
+                    # All nodes in the target generations should have an individual
+                    assert np.all(ts.tables.nodes.individual[nodes] >= 0)
+                for tree in ts.trees():
+                    assert np.all(np.isin(tree.roots, nodes_at_start))
+                    for gen, nodes in nodes_at_gen.items():
+                        treenodes_at_gen = set(tree.nodes()) & set(nodes)
+                        assert len(treenodes_at_gen) == self.num_lineages_at_time(
+                            ts, gen, tree.interval.left)
+
+    @pytest.mark.parametrize('recipe, gens, final_gen', indirect=["recipe"], argvalues=[
+        ('test_____retain_and_remember_individuals.slim', (50, 100), 200),
+    ])
+    def test_not_all_lineages_covered(self, recipe, gens, final_gen):
+        """
+        If all individuals in `gen` are retained with retainCoalescentOnly=T, we should
+        simplify out those with only unary nodes, and not all lineages will have a node
+        """
+        gens = final_gen - np.array(gens)  # convert to ts times
+        for result in recipe["results"]:
+            for ts in result.get_ts():
+                # Check all initial generation nodes are roots
+                nodes_at_start = np.where(ts.tables.nodes.time == final_gen)[0]
+                nodes_at_gen = {g: np.where(ts.tables.nodes.time == g)[0] for g in gens}
+                for nodes in nodes_at_gen.values():
+                    # All nodes in the target generations should have an individual
+                    assert np.all(ts.tables.nodes.individual[nodes] >= 0)
+                for tree in ts.trees():
+                    assert np.all(np.isin(tree.roots, nodes_at_start))
+                    for gen, nodes in nodes_at_gen.items():
+                        treenodes_at_gen = set(tree.nodes()) & set(nodes)
+                        assert len(treenodes_at_gen) < self.num_lineages_at_time(
+                            ts, gen, tree.interval.left)

--- a/treerec/tskit/tables.c
+++ b/treerec/tskit/tables.c
@@ -6644,7 +6644,7 @@ simplifier_merge_ancestors(simplifier_t *self, tsk_id_t input_id)
         keep_unary = true;
     }
     if ((self->options & TSK_KEEP_UNARY_IN_INDIVIDUALS)
-        && (self->tables->nodes.individual[input_id] != TSK_NULL)) {
+        && (self->input_tables.nodes.individual[input_id] != TSK_NULL)) {
         keep_unary = true;
     }
 


### PR DESCRIPTION
As it might be a little while until the tskit fix for keep unary in individuals makes it into a release, I have hacked in the fix by hand in the PR. I have also renamed some of the tests as per https://github.com/MesserLab/SLiM/pull/142#issuecomment-768457197 to replace `000` with `___` which I think is less confusing. There's also a new suite of python tests intended to test the results of specific SLiM recipes, rather than more general tests of any TS produced by SLiM.

I'm now move on to documenting this in pyslim, so that @petrelharp can release a compatible version.