### PR TITLE
Update GitHub Action to use latest GCC (v11).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
             gcc: 4.8
           # Ubuntu with the most recent GCC.
           - os: ubuntu-20.04
-            gcc: 10
+            gcc: 11
 
     steps:
       - name: Checkout
@@ -150,7 +150,7 @@ jobs:
           # Ubuntu with the most recent Qt and GCC.
           - os: ubuntu-20.04
             qt: 5.15.2
-            gcc: 10
+            gcc: 11
           # MacOS with oldest supported Qt.
           - os: macos-10.15
             qt: 5.9.5


### PR DESCRIPTION
SLiM v3.6 has a build issue with GCC-11 (fixed by https://github.com/MesserLab/SLiM/commit/7964f7911e1665a1ba0783d9136b3d3bff06d931). See https://www.gnu.org/software/gcc/gcc-11/porting_to.html for details of header changes. By testing on GCC-11, we help ensure there are no regressions in the future.

Thanks to Clemens Schmid (@nevrome) for alerting me to this via the Arch Linux package.