### PR TITLE
update tskit (including bigtables code)

### DIFF
--- a/treerec/_README
+++ b/treerec/_README
@@ -29,3 +29,4 @@ The code in `tskit/kastore` is from [kastore/c](https://github.com/tskit-dev/kas
 - *27 August 2020*: updated to tskit C_0.99.5
 - *12 August 2020*: updated to tskit C_0.99.4 and kastore 0.3.0.
 - *10 June 2021*: updated to tskit 0.3.6 and kastore 0.3.1.
+- *7 Sept 2021*: updated to tskit C_0.99.14

--- a/treerec/tskit/convert.c
+++ b/treerec/tskit/convert.c
@@ -42,7 +42,7 @@
  * pointless. */
 
 typedef struct {
-    size_t precision;
+    unsigned int precision;
     tsk_flags_t options;
     char *newick;
     tsk_id_t *traversal_stack;
@@ -98,7 +98,7 @@ tsk_newick_converter_run(
                 }
                 /* We do this for ms-compatability. This should be a configurable option
                  * via the flags attribute */
-                label = v + 1;
+                label = (int) v + 1;
                 r = snprintf(buffer + s, buffer_size - s, "%d", label);
                 if (r < 0) {
                     ret = TSK_ERR_IO;
@@ -145,16 +145,17 @@ out:
 
 static int
 tsk_newick_converter_init(tsk_newick_converter_t *self, const tsk_tree_t *tree,
-    size_t precision, tsk_flags_t options)
+    unsigned int precision, tsk_flags_t options)
 {
     int ret = 0;
 
-    memset(self, 0, sizeof(tsk_newick_converter_t));
+    tsk_memset(self, 0, sizeof(tsk_newick_converter_t));
     self->precision = precision;
     self->options = options;
     self->tree = tree;
-    self->traversal_stack = malloc(tsk_treeseq_get_num_nodes(self->tree->tree_sequence)
-                                   * sizeof(*self->traversal_stack));
+    self->traversal_stack
+        = tsk_malloc(tsk_treeseq_get_num_nodes(self->tree->tree_sequence)
+                     * sizeof(*self->traversal_stack));
     if (self->traversal_stack == NULL) {
         ret = TSK_ERR_NO_MEMORY;
         goto out;
@@ -171,7 +172,7 @@ tsk_newick_converter_free(tsk_newick_converter_t *self)
 }
 
 int
-tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, unsigned int precision,
     tsk_flags_t options, size_t buffer_size, char *buffer)
 {
     int ret = 0;

--- a/treerec/tskit/convert.h
+++ b/treerec/tskit/convert.h
@@ -32,7 +32,7 @@ extern "C" {
 
 #include <tskit/trees.h>
 
-int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, unsigned int precision,
     tsk_flags_t options, size_t buffer_size, char *buffer);
 
 #ifdef __cplusplus

--- a/treerec/tskit/genotypes.h
+++ b/treerec/tskit/genotypes.h
@@ -49,14 +49,14 @@ typedef struct {
 } tsk_variant_t;
 
 typedef struct {
-    size_t num_samples;
-    size_t num_sites;
+    tsk_size_t num_samples;
+    tsk_size_t num_sites;
     const tsk_treeseq_t *tree_sequence;
     const tsk_id_t *samples;          /* samples being used */
     const tsk_id_t *sample_index_map; /* reverse index map being used */
     bool user_alleles;
     char *user_alleles_mem;
-    size_t tree_site_index;
+    tsk_size_t tree_site_index;
     int finished;
     tsk_id_t *traversal_stack;
     tsk_tree_t tree;
@@ -68,7 +68,7 @@ typedef struct {
 } tsk_vargen_t;
 
 int tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
-    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    const tsk_id_t *samples, tsk_size_t num_samples, const char **alleles,
     tsk_flags_t options);
 int tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant);
 int tsk_vargen_free(tsk_vargen_t *self);

--- a/treerec/tskit/haplotype_matching.h
+++ b/treerec/tskit/haplotype_matching.h
@@ -42,7 +42,7 @@ typedef struct {
 } tsk_value_transition_t;
 
 typedef struct {
-    size_t index;
+    tsk_size_t index;
     double value;
 } tsk_argsort_t;
 
@@ -81,8 +81,8 @@ typedef struct {
 typedef struct {
     tsk_compressed_matrix_t matrix;
     tsk_recomb_required_record *recombination_required;
-    size_t num_recomb_records;
-    size_t max_recomb_records;
+    tsk_size_t num_recomb_records;
+    tsk_size_t max_recomb_records;
 } tsk_viterbi_matrix_t;
 
 typedef struct _tsk_ls_hmm_t {
@@ -109,14 +109,14 @@ typedef struct _tsk_ls_hmm_t {
     tsk_id_t *transition_index;
     /* Buffer used to argsort the transitions by node time */
     tsk_argsort_t *transition_time_order;
-    size_t num_transitions;
-    size_t max_transitions;
+    tsk_size_t num_transitions;
+    tsk_size_t max_transitions;
     /* The distinct values in the transitions */
     double *values;
-    size_t num_values;
-    size_t max_values;
+    tsk_size_t num_values;
+    tsk_size_t max_values;
     /* Number of machine words per node optimal value set. */
-    size_t num_optimal_value_set_words;
+    tsk_size_t num_optimal_value_set_words;
     uint64_t *optimal_value_sets;
     /* The parent transition; used during compression */
     tsk_id_t *transition_parent;
@@ -144,7 +144,7 @@ int tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
     double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *), void *output);
 
 int tsk_compressed_matrix_init(tsk_compressed_matrix_t *self,
-    tsk_treeseq_t *tree_sequence, size_t block_size, tsk_flags_t options);
+    tsk_treeseq_t *tree_sequence, tsk_size_t block_size, tsk_flags_t options);
 int tsk_compressed_matrix_free(tsk_compressed_matrix_t *self);
 int tsk_compressed_matrix_clear(tsk_compressed_matrix_t *self);
 void tsk_compressed_matrix_print_state(tsk_compressed_matrix_t *self, FILE *out);
@@ -154,7 +154,7 @@ int tsk_compressed_matrix_store_site(tsk_compressed_matrix_t *self, tsk_id_t sit
 int tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values);
 
 int tsk_viterbi_matrix_init(tsk_viterbi_matrix_t *self, tsk_treeseq_t *tree_sequence,
-    size_t block_size, tsk_flags_t options);
+    tsk_size_t block_size, tsk_flags_t options);
 int tsk_viterbi_matrix_free(tsk_viterbi_matrix_t *self);
 int tsk_viterbi_matrix_clear(tsk_viterbi_matrix_t *self);
 void tsk_viterbi_matrix_print_state(tsk_viterbi_matrix_t *self, FILE *out);

--- a/treerec/tskit/stats.c
+++ b/treerec/tskit/stats.c
@@ -33,8 +33,8 @@
 static void
 tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
 {
-    uint32_t u;
-    uint32_t num_nodes = (uint32_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    tsk_size_t u;
+    tsk_size_t num_nodes = tsk_treeseq_get_num_nodes(self->tree_sequence);
     tsk_tree_t *tA = self->outer_tree;
     tsk_tree_t *tB = self->inner_tree;
 
@@ -51,10 +51,10 @@ void
 tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out)
 {
     fprintf(out, "tree_sequence = %p\n", (const void *) self->tree_sequence);
-    fprintf(out, "outer tree index = %d\n", (int) self->outer_tree->index);
+    fprintf(out, "outer tree index = %lld\n", (long long) self->outer_tree->index);
     fprintf(out, "outer tree interval = (%f, %f)\n", self->outer_tree->left,
         self->outer_tree->right);
-    fprintf(out, "inner tree index = %d\n", (int) self->inner_tree->index);
+    fprintf(out, "inner tree index = %lld\n", (long long) self->inner_tree->index);
     fprintf(out, "inner tree interval = (%f, %f)\n", self->inner_tree->left,
         self->inner_tree->right);
     tsk_ld_calc_check_state(self);
@@ -65,11 +65,11 @@ tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence)
 {
     int ret = TSK_ERR_GENERIC;
 
-    memset(self, 0, sizeof(tsk_ld_calc_t));
+    tsk_memset(self, 0, sizeof(tsk_ld_calc_t));
     self->tree_sequence = tree_sequence;
     self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
-    self->outer_tree = malloc(sizeof(tsk_tree_t));
-    self->inner_tree = malloc(sizeof(tsk_tree_t));
+    self->outer_tree = tsk_malloc(sizeof(tsk_tree_t));
+    self->inner_tree = tsk_malloc(sizeof(tsk_tree_t));
     if (self->outer_tree == NULL || self->inner_tree == NULL) {
         ret = TSK_ERR_NO_MEMORY;
         goto out;

--- a/treerec/tskit/trees.h
+++ b/treerec/tskit/trees.h
@@ -54,6 +54,9 @@ extern "C" {
 #define TSK_STAT_POLARISED          (1 << 10)
 #define TSK_STAT_SPAN_NORMALISE     (1 << 11)
 
+/* Options for map_mutations */
+#define TSK_MM_FIXED_ANCESTRAL_STATE (1 << 0)
+
 #define TSK_DIR_FORWARD 1
 #define TSK_DIR_REVERSE -1
 
@@ -165,6 +168,7 @@ typedef struct {
      * from a specific subset. By default sample counts are tracked and roots
      * maintained. If TSK_NO_SAMPLE_COUNTS is specified, then neither sample
      * counts or roots are available. */
+    /* TODO should these be tsk_size_t values? */
     tsk_id_t *num_samples;
     tsk_id_t *num_tracked_samples;
     /* TODO the only place this feature seems to be used is in the ld_calculator.
@@ -279,20 +283,18 @@ int tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *othe
     double lambda_, double *result);
 
 int tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
-    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
-    const size_t *reference_set_size, size_t num_reference_sets, tsk_flags_t options,
-    double *ret_array);
+    const tsk_id_t *focal, tsk_size_t num_focal, const tsk_id_t *const *reference_sets,
+    const tsk_size_t *reference_set_size, tsk_size_t num_reference_sets,
+    tsk_flags_t options, double *ret_array);
 int tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
-    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
-    size_t num_reference_sets, tsk_flags_t options, double *ret_array);
+    const tsk_id_t *const *reference_sets, const tsk_size_t *reference_set_size,
+    tsk_size_t num_reference_sets, tsk_flags_t options, double *ret_array);
 
-/* TODO change all these size_t's to tsk_size_t */
+typedef int general_stat_func_t(tsk_size_t state_dim, const double *state,
+    tsk_size_t result_dim, double *result, void *params);
 
-typedef int general_stat_func_t(size_t state_dim, const double *state, size_t result_dim,
-    double *result, void *params);
-
-int tsk_treeseq_general_stat(const tsk_treeseq_t *self, size_t K, const double *W,
-    size_t M, general_stat_func_t *f, void *f_params, size_t num_windows,
+int tsk_treeseq_general_stat(const tsk_treeseq_t *self, tsk_size_t K, const double *W,
+    tsk_size_t M, general_stat_func_t *f, void *f_params, tsk_size_t num_windows,
     const double *windows, double *sigma, tsk_flags_t options);
 
 /* One way weighted stats */
@@ -415,16 +417,17 @@ bool tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u);
 
 int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
 int tsk_tree_set_tracked_samples(
-    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples);
+    tsk_tree_t *self, tsk_size_t num_tracked_samples, const tsk_id_t *tracked_samples);
 int tsk_tree_set_tracked_samples_from_sample_list(
     tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node);
 
 int tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent);
 int tsk_tree_get_time(const tsk_tree_t *self, tsk_id_t u, double *t);
 int tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca);
-int tsk_tree_get_num_samples(const tsk_tree_t *self, tsk_id_t u, size_t *num_samples);
+int tsk_tree_get_num_samples(
+    const tsk_tree_t *self, tsk_id_t u, tsk_size_t *num_samples);
 int tsk_tree_get_num_tracked_samples(
-    const tsk_tree_t *self, tsk_id_t u, size_t *num_tracked_samples);
+    const tsk_tree_t *self, tsk_id_t u, tsk_size_t *num_tracked_samples);
 int tsk_tree_get_sites(
     const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length);
 int tsk_tree_depth(const tsk_tree_t *self, tsk_id_t u, tsk_size_t *depth);


### PR DESCRIPTION
Closes #206.  But, this hasn't changed anything, I don't think - IIUC, we need to define `_TSK_BIG_TABLES` to turn on bigtableness - see the new note at the top of `treerec/tskit/core.h`.