### PR TITLE
Windows_port typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(WIN32)
         "${PROJECT_SOURCE_DIR}/core/slim_globals.cpp"
         "${PROJECT_SOURCE_DIR}/core/slim_sim_eidos.cpp"
         "${PROJECT_SOURCE_DIR}/core/slim_sim.cpp"
-        "${PROJECT_SOURCE_DIR}/core/subpopulation.cpp",
+        "${PROJECT_SOURCE_DIR}/core/subpopulation.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_functions.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_globals.cpp"
         "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMAbout.cpp"


### PR DESCRIPTION
I noticed a small typo in CMakeLists.txt (unnecessary comma). It didn't seem to cause any problems in the build, but good to clean it up anyway probably.