### PR TITLE
fixed bug where build would fail if BUILD_SLIMGUI=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,8 @@ if(WIN32)
         "${PROJECT_SOURCE_DIR}/core/slim_sim.cpp"
         "${PROJECT_SOURCE_DIR}/core/subpopulation.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_functions.cpp"
-        "${PROJECT_SOURCE_DIR}/eidos/eidos_globals.cpp"
-        "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMAbout.cpp"
+        "${PROJECT_SOURCE_DIR}/eidos/eidos_globals.cpp")
+    set(GNULIB_NAMESPACE_SOURCES_SLIMGUI "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMAbout.cpp"
         "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMAppDelegate.cpp"
         "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMFindRecipe.cpp"
         "${PROJECT_SOURCE_DIR}/QtSLiM/QtSLiMGraphView.cpp"
@@ -198,6 +198,7 @@ if(WIN32)
     set_source_files_properties(${EIDOS_SOURCES} PROPERTIES COMPILE_FLAGS "-include config.h")
     target_include_directories(${TARGET_NAME} BEFORE PUBLIC ${GNU_DIR})
     target_link_libraries(${TARGET_NAME} PUBLIC gnu)
+    set_source_files_properties(${GNULIB_NAMESPACE_SOURCES} TARGET_DIRECTORY slim eidos PROPERTIES COMPILE_FLAGS "-include config.h -DGNULIB_NAMESPACE=gnulib")
 endif()
 
 install(TARGETS slim eidos DESTINATION bin)
@@ -229,7 +230,7 @@ if(APPLE)
 else()
     if(WIN32)
         set_source_files_properties(${QTSLIM_SOURCES} PROPERTIES COMPILE_FLAGS "-include config.h")
-        set_source_files_properties(${GNULIB_NAMESPACE_SOURCES} TARGET_DIRECTORY slim eidos SLiMgui PROPERTIES COMPILE_FLAGS "-include config.h -DGNULIB_NAMESPACE=gnulib")
+        set_source_files_properties(${GNULIB_NAMESPACE_SOURCES_SLIMGUI} TARGET_DIRECTORY SLiMgui PROPERTIES COMPILE_FLAGS "-include config.h -DGNULIB_NAMESPACE=gnulib")
         target_include_directories(${TARGET_NAME} BEFORE PUBLIC ${GNU_DIR})
         target_link_libraries(${TARGET_NAME} PUBLIC Qt5::Widgets Qt5::Core Qt5::Gui OpenGL::GL gsl tables eidos_zlib gnu )
     else()


### PR DESCRIPTION
Okay, fixed issue that meant BUILD_SLIMGUI=OFF build would fail. At some point `SLiM_pacman.tar.gz` should be updated but currently pacman only builds with BUILD_SLIMGUI=ON, so it works fine at the moment. If tests pass, it should be fine to merge this into master now. I will work on a new PR to get github actions tests for Windows working next. I don't think that will be too difficult.