### PR TITLE
fix to python recipes

### DIFF
--- a/QtSLiM/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models II.py
+++ b/QtSLiM/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models II.py
@@ -11,7 +11,7 @@ for mut in ts.mutations():
     k = np.argmax([u["slim_time"] for u in mut_list])
     derived_nuc = mut_list[k]["nucleotide"]
     if mut.parent == -1:
-        acgt = ts.reference_sequence[int(mut.position)]
+        acgt = ts.reference_sequence.data[int(ts.site(mut.site).position)]
         parent_nuc = pyslim.NUCLEOTIDES.index(acgt)
     else:
         parent_mut = ts.mutation(mut.parent)

--- a/QtSLiM/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models III.py
+++ b/QtSLiM/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models III.py
@@ -19,7 +19,7 @@ for mut in ts.mutations():
         right_nuc = ts.nucleotide_at(mut.node, pos + 1,
                 time = slim_gen - mut_list[k]["slim_time"] - 1.0)
         if mut.parent == -1:
-            acgt = ts.reference_sequence[int(mut.position)]
+            acgt = ts.reference_sequence.data[int(ts.site(mut.site).position)]
             parent_nuc = pyslim.NUCLEOTIDES.index(acgt)
         else:
             parent_mut = ts.mutation(mut.parent)


### PR DESCRIPTION
There was one error here (mutation objects don't have a `.position` attribute, sites do), and one API change (it's now `reference_sequence.data` for the actual reference sequence).

Closes #267 