### PR TITLE
Use standards-compliant printf %e format specifier on Windows.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,13 +190,6 @@ jobs:
           qmake ..
           make -j 2
 
-  # Just test that the repository can be cloned on windows.
-  tests-windows-clone:
-    runs-on: windows-2019
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        
   # test windows-latest compilation
   tests-windows-latest-CLI:
     runs-on: windows-latest
@@ -228,6 +221,7 @@ jobs:
           msys2-devel
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-cmake
+          automake1.16
 
     - name: Cache conda and dependancies
       id: cache
@@ -331,6 +325,7 @@ jobs:
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-qt5-base
+          automake1.16
 
     - name: Build (cmake)
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,6 +222,7 @@ jobs:
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-cmake
           automake1.16
+          autoconf
 
     - name: Cache conda and dependancies
       id: cache
@@ -326,6 +327,7 @@ jobs:
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-qt5-base
           automake1.16
+          autoconf
 
     - name: Build (cmake)
       run: |

--- a/eidos/eidos_globals.cpp
+++ b/eidos/eidos_globals.cpp
@@ -335,7 +335,7 @@ void Eidos_WarmUp(void)
 			exit(0);
 		}
 
-#if (defined(_MSC_VER) && _MSC_VER <= 1900) || defined(__MINGW32__)
+#if (defined(_MSC_VER) && _MSC_VER <= 1900) || (defined(__MINGW32__) && !defined(_UCRT))
 		// Work around non-conformance of Microsoft's printf %e format specifier,
 		// which uses 3 digits for the exponent instead of 2.
 		// Until Visual Studio 2015, the _set_output_format() function can be used to obtain standards compliant behaviour.

--- a/eidos/eidos_globals.cpp
+++ b/eidos/eidos_globals.cpp
@@ -334,6 +334,20 @@ void Eidos_WarmUp(void)
 			std::cerr << "***** Class name mismatch in Eidos_WarmUp()!";
 			exit(0);
 		}
+
+#ifdef _WIN32
+		// Work around non-conformance of Microsoft's printf %e format specifier,
+		// which uses 3 digits for the exponent instead of 2.
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+		// Until Visual Studio 2015, the _set_output_format() function can be used to obtain standards compliant behaviour.
+		// More recent Visual Studio compilers are standards compliant.
+		_set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
+#ifdef __MINGW32__
+		// Mingw can read from an environment variable to get the desired 2-digit behaviour.
+		setenv("PRINTF_EXPONENT_DIGITS", "2");
+#endif
+#endif
 	}
 }
 

--- a/eidos/eidos_globals.cpp
+++ b/eidos/eidos_globals.cpp
@@ -335,18 +335,12 @@ void Eidos_WarmUp(void)
 			exit(0);
 		}
 
-#ifdef _WIN32
+#if (defined(_MSC_VER) && _MSC_VER <= 1900) || defined(__MINGW32__)
 		// Work around non-conformance of Microsoft's printf %e format specifier,
 		// which uses 3 digits for the exponent instead of 2.
-#if defined(_MSC_VER) && _MSC_VER <= 1900
 		// Until Visual Studio 2015, the _set_output_format() function can be used to obtain standards compliant behaviour.
-		// More recent Visual Studio compilers are standards compliant.
+		// More recent Visual Studio compilers are standards compliant, and Mingw provides _set_output_format() since 2008.
 		_set_output_format(_TWO_DIGIT_EXPONENT);
-#endif
-#ifdef __MINGW32__
-		// Mingw can read from an environment variable to get the desired 2-digit behaviour.
-		setenv("PRINTF_EXPONENT_DIGITS", "2");
-#endif
 #endif
 	}
 }


### PR DESCRIPTION
This only affects older compilers which link against msvcrt.dll
instead of the newer ucrt.dll.