### PR TITLE
Windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -266,7 +266,7 @@ jobs:
     - name: Debug
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
+        touch --date="`date`" aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         mkdir Debug
         cd Debug
@@ -276,7 +276,7 @@ jobs:
     - name: Build (Release)
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
+        touch --date="`date`" aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         mkdir Release
         cd Release
@@ -333,7 +333,7 @@ jobs:
     - name: Build (cmake)
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
+        touch --date="`date`" aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         # Just do a release build.
         mkdir Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,8 +220,6 @@ jobs:
           msys2-devel
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-cmake
-          automake1.16
-          autoconf
 
     - name: Cache conda and dependancies
       id: cache
@@ -232,7 +230,7 @@ jobs:
           /usr/share/miniconda/envs/anaconda-client-env
           ~/osx-conda
           ~/.profile
-        key: ${{ runner.os }}-${{ matrix.python}}-conda-v14-${{ hashFiles('treerec/tests/conda-requirements.txt') }}-${{ hashFiles('treerec/tests/pip-requirements.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python}}-conda-v15-${{ hashFiles('treerec/tests/conda-requirements.txt') }}-${{ hashFiles('treerec/tests/pip-requirements.txt') }}
 
     - name: Install Conda
       uses: conda-incubator/setup-miniconda@v2
@@ -250,13 +248,13 @@ jobs:
       shell: pwsh
       run: |
         C:\Miniconda\condabin\conda.bat install --yes --file=treerec/tests/conda-requirements.txt
-        C:\Miniconda\condabin\conda.bat install --yes --file=treerec/tests/pip-requirements.txt
         C:\Miniconda\condabin\conda.bat init powershell
 
     - name: Install pip deps
       if: steps.cache.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
+        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
         pip install -r treerec/tests/pip-requirements.txt
 
     - name: Install pyslim
@@ -325,8 +323,6 @@ jobs:
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-cmake
           mingw-w64-${{matrix.env}}-qt5-base
-          automake1.16
-          autoconf
 
     - name: Build (cmake)
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -266,7 +266,7 @@ jobs:
     - name: Debug
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure Makefile.in
+        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         mkdir Debug
         cd Debug
@@ -276,7 +276,7 @@ jobs:
     - name: Build (Release)
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure Makefile.in
+        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         mkdir Release
         cd Release
@@ -333,7 +333,7 @@ jobs:
     - name: Build (cmake)
       run: |
         cd windows_compat/gnulib
-        touch aclocal.m4 Makefile.am configure Makefile.in
+        touch aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..
         # Just do a release build.
         mkdir Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -265,6 +265,9 @@ jobs:
 
     - name: Debug
       run: |
+        cd windows_compat/gnulib
+        touch aclocal.m4 Makefile.am configure Makefile.in
+        cd ../..
         mkdir Debug
         cd Debug
         cmake -G"MSYS Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
@@ -272,6 +275,9 @@ jobs:
 
     - name: Build (Release)
       run: |
+        cd windows_compat/gnulib
+        touch aclocal.m4 Makefile.am configure Makefile.in
+        cd ../..
         mkdir Release
         cd Release
         cmake -G"MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release ..
@@ -326,6 +332,9 @@ jobs:
 
     - name: Build (cmake)
       run: |
+        cd windows_compat/gnulib
+        touch aclocal.m4 Makefile.am configure Makefile.in
+        cd ../..
         # Just do a release build.
         mkdir Release
         cd Release


### PR DESCRIPTION
fixes #277. All tests pass on my fork. Let's see if they pass in this PR. 

To deal with the `pytest` related error I just made sure the correct conda environment was activated before running `pip` (not sure why it worked originally since I had forgotten to do this ?). I also revisited the `aclocal not found` issue, which was originally solved by installing `automake`. Instead I updated the timestamps of the relevant files. github checkout does not update timestamps which was making autoconf think that the files were out of date and needed to be regenerated. This hopefully won't be an issue for users because they will be extracting SLiM from an archive, which does update timestamps. If this does become an issue for users, one possible solution down the line would be to do the timestamp updating in cmake.