### PR TITLE
fix Windows tests caching issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,8 +227,7 @@ jobs:
       with:
         path: |
           c:\Miniconda\envs\anaconda-client-env
-          /usr/share/miniconda/envs/anaconda-client-env
-          ~/osx-conda
+          ~/.bash_profile
           ~/.profile
         key: ${{ runner.os }}-${{ matrix.python}}-conda-v16-${{ hashFiles('treerec/tests/conda-requirements.txt') }}-${{ hashFiles('treerec/tests/pip-requirements.txt') }}
 
@@ -290,8 +289,8 @@ jobs:
     - name: Treesequence tests
       shell: bash -l {0}
       run: |
-        export PATH=$PATH:$(pwd)\Release
-        cd treerec\tests 
+        export PATH=$PATH:$(pwd)/Release
+        cd treerec/tests 
         python -m pytest -xv
 
   tests-windows-latest-GUI:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,25 +245,20 @@ jobs:
 
     - name: Install conda deps
       if: steps.cache.outputs.cache-hit != 'true'
-      shell: pwsh
+      shell: bash -l {0}
       run: |
-        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
-        C:\Miniconda\condabin\conda.bat install --yes --file=treerec/tests/conda-requirements.txt
-        C:\Miniconda\condabin\conda.bat init powershell
+        conda install --yes --file=treerec/tests/conda-requirements.txt
 
     - name: Install pip deps
       if: steps.cache.outputs.cache-hit != 'true'
-      shell: pwsh
+      shell: bash -l {0}
       run: |
-        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
         pip install -r treerec/tests/pip-requirements.txt
 
     - name: Install pyslim
-      shell: pwsh
+      shell: bash -l {0}
       run: |
-        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
-        C:\Miniconda\condabin\conda.bat init powershell
-        C:\Miniconda\condabin\conda.bat install -c conda-forge pyslim
+        conda install -c conda-forge pyslim
 
     - name: Debug
       run: |
@@ -293,10 +288,9 @@ jobs:
         ./slim -testSLiM
     
     - name: Treesequence tests
-      shell: pwsh
+      shell: bash -l {0}
       run: |
-        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
-        $env:path += ";$(pwd)\Release"
+        export PATH=$PATH:$(pwd)\Release
         cd treerec\tests 
         python -m pytest -xv
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -327,6 +327,7 @@ jobs:
 
     - name: Build (cmake)
       run: |
+        cd .
         cd windows_compat/gnulib
         touch --date="`date`" aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
         cd ../..

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,7 +230,7 @@ jobs:
           /usr/share/miniconda/envs/anaconda-client-env
           ~/osx-conda
           ~/.profile
-        key: ${{ runner.os }}-${{ matrix.python}}-conda-v15-${{ hashFiles('treerec/tests/conda-requirements.txt') }}-${{ hashFiles('treerec/tests/pip-requirements.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python}}-conda-v16-${{ hashFiles('treerec/tests/conda-requirements.txt') }}-${{ hashFiles('treerec/tests/pip-requirements.txt') }}
 
     - name: Install Conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,6 +247,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
+        C:\Miniconda\condabin\conda.bat activate anaconda-client-env
         C:\Miniconda\condabin\conda.bat install --yes --file=treerec/tests/conda-requirements.txt
         C:\Miniconda\condabin\conda.bat init powershell
 
@@ -261,6 +262,7 @@ jobs:
       shell: pwsh
       run: |
         C:\Miniconda\condabin\conda.bat activate anaconda-client-env
+        C:\Miniconda\condabin\conda.bat init powershell
         C:\Miniconda\condabin\conda.bat install -c conda-forge pyslim
 
     - name: Debug


### PR DESCRIPTION
Okay, I think this works now (fixes #277). I tested the caching by making a trivial change to get the workflow to run a second time. It used the cache and the tests worked. So hopefully this will keep working now. It was switching to bash instead of powershell that did the trick. So it was really a poor choice of mine early on that caused all this. Apologies for all the time you all have spent on this, but thanks for all your help finding the issue.