### PR TITLE
fix multispecies on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if(WIN32)
         "${PROJECT_SOURCE_DIR}/core/slim_globals.cpp"
         "${PROJECT_SOURCE_DIR}/core/slim_sim_eidos.cpp"
         "${PROJECT_SOURCE_DIR}/core/slim_sim.cpp"
+        "${PROJECT_SOURCE_DIR}/core/species.cpp"
         "${PROJECT_SOURCE_DIR}/core/subpopulation.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_functions.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_globals.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(WIN32)
         "${PROJECT_SOURCE_DIR}/core/slim_sim_eidos.cpp"
         "${PROJECT_SOURCE_DIR}/core/slim_sim.cpp"
         "${PROJECT_SOURCE_DIR}/core/species.cpp"
+        "${PROJECT_SOURCE_DIR}/core/species_eidos.cpp"
         "${PROJECT_SOURCE_DIR}/core/subpopulation.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_functions.cpp"
         "${PROJECT_SOURCE_DIR}/eidos/eidos_globals.cpp"


### PR DESCRIPTION
As you suspected, a pretty easy fix (still fails but it does so on treesequence tests, just like the linux tests). If you see similar errors in the future, they will likely be fixed by adding the problematic source files into the `GNULIB_NAMESPACE_SOURCES` list in `CMakeLists.txt`. Fixes #299 .