### PR TITLE
Fix URL to a downloadable resource

### DIFF
--- a/org.messerlab.slimgui.appdata.xml
+++ b/org.messerlab.slimgui.appdata.xml
@@ -13,7 +13,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-        <image>https://github.com/bryce-carson/SLiM/blob/ab1a982d6f6238d1702cd6a146b4b90019a566d4/org.messerlab.slimgui.screenshot.png</image>
+        <image>https://raw.githubusercontent.com/bryce-carson/SLiM/ab1a982d6f6238d1702cd6a146b4b90019a566d4/org.messerlab.slimgui.screenshot.png</image>
     </screenshot>
   </screenshots>
   <!-- LINKS to display in "Software Center" applications-->

--- a/org.messerlab.slimgui.metainfo.xml
+++ b/org.messerlab.slimgui.metainfo.xml
@@ -17,7 +17,7 @@
   <launchable type="desktop-id">org.messerlab.slimgui.desktop</launchable>
   <screenshots>
       <screenshot type="default">
-          <image>https://github.com/bryce-carson/SLiM/blob/ab1a982d6f6238d1702cd6a146b4b90019a566d4/org.messerlab.slimgui.screenshot.png</image>
+          <image>https://raw.githubusercontent.com/bryce-carson/SLiM/ab1a982d6f6238d1702cd6a146b4b90019a566d4/org.messerlab.slimgui.screenshot.png</image>
       </screenshot>
   </screenshots>
   <!-- LINKS to display in "Software Center" applications-->


### PR DESCRIPTION
The URL was not from the _raw_ GitHub domain, so the actual file was not downloadable from the URL previously used.