### PR TITLE
note explaining current status of slim_id in population table

### DIFF
--- a/core/species.cpp
+++ b/core/species.cpp
@@ -7177,8 +7177,9 @@ void Species::__RemapSubpopulationIDs(SUBPOP_REMAP_HASH &p_subpop_map, int p_fil
 					// and we will remap it and fix up its metadata
 					slim_objectid_t slim_id = subpop_metadata["slim_id"].get<slim_objectid_t>();
 					
-					// enforce the slim_id == index invariant here; it is not clear that we really need this
-					// invariant, but I'm going to enforce it for now so I don't have to think about it
+					// enforce the slim_id == index invariant here; removing this invariant would be
+					// possible but would require a bunch of bookeeping and checks; see treerec/implementation.md
+                    // for more discussion of this
 					if (slim_id != subpop_id)
 						EIDOS_TERMINATION << "ERROR (Species::__RemapSubpopulationIDs): population metadata value for key 'slim_id' is not equal to the table index; this file cannot be read." << EidosTerminate(nullptr);
 					

--- a/treerec/implementation.md
+++ b/treerec/implementation.md
@@ -170,6 +170,19 @@ In other words, the state of the population table represents the state of things
 non-SLiM entries in it which got carried over by SLiM from a tree sequence
 that was read in.
 
+We also require the "slim_id" key in metadata to match the row of the population table
+in which it is found. The reason for this is because we may refer to (sub)population IDs
+in several places: (a) the population column of the node table; (b) the subpopulation
+entry of the individual metadata; (c) the subpopulation entry of the mutation metadata.
+Of these, (a) is exposed to tskit (and so will remain consistent under tskit operations)
+but (b) and (c) are not. However, SLiM will ensure that (a), (b), and (c) remain consistent.
+It would be possible to decouple row of the population table with "slim_id" entry in metadata,
+by simply declaring that things referred to in metadata refer to the slim_id of a population's
+metadata, while the population column in tables refers to the population id as usual.
+However, this would then require substantial downstream consistency checking:
+for instance, individual->node->population.metadata["slim_id"] should always
+equal individual.metadata["subpopulation"] . We would also need to ensure that the slim_id's
+were always unique.
 
 ## Metadata schemas
 


### PR DESCRIPTION
I had a go at removing the requirement that metadata and population row match, but discovered its tentacles reaching out further than I anticipated. Here's the result.

Closes #390 .