### PR TITLE
Added functions for extracting upper and lower triangles of matrices

### DIFF
--- a/eidos/eidos_functions.cpp
+++ b/eidos/eidos_functions.cpp
@@ -256,7 +256,9 @@ const std::vector<EidosFunctionSignature_CSP> &EidosInterpreter::BuiltInFunction
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("nrow",				Eidos_ExecuteFunction_nrow,			kEidosValueMaskInt | kEidosValueMaskSingleton))->AddAny("x"));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("rbind",				Eidos_ExecuteFunction_rbind,		kEidosValueMaskAny))->AddEllipsis());
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("t",					Eidos_ExecuteFunction_t,			kEidosValueMaskAny))->AddAny("x"));
-		
+		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("upperTri",			Eidos_ExecuteFunction_upperTri,		kEidosValueMaskAny))->AddAny("x")->AddLogical_OS("diag", gStaticEidosValue_LogicalF));
+		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("lowerTri",			Eidos_ExecuteFunction_lowerTri,		kEidosValueMaskAny))->AddAny("x")->AddLogical_OS("diag", gStaticEidosValue_LogicalF));
+
 		
 		// ************************************************************************************
 		//

--- a/eidos/eidos_functions.cpp
+++ b/eidos/eidos_functions.cpp
@@ -258,6 +258,7 @@ const std::vector<EidosFunctionSignature_CSP> &EidosInterpreter::BuiltInFunction
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("t",					Eidos_ExecuteFunction_t,			kEidosValueMaskAny))->AddAny("x"));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("upperTri",			Eidos_ExecuteFunction_upperTri,		kEidosValueMaskAny))->AddAny("x")->AddLogical_OS("diag", gStaticEidosValue_LogicalF));
 		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("lowerTri",			Eidos_ExecuteFunction_lowerTri,		kEidosValueMaskAny))->AddAny("x")->AddLogical_OS("diag", gStaticEidosValue_LogicalF));
+		signatures->emplace_back((EidosFunctionSignature *)(new EidosFunctionSignature("diag",				Eidos_ExecuteFunction_diag,			kEidosValueMaskAny))->AddAny_O("x", gStaticEidosValue_Integer1)->AddInt_OSN("nrow", gStaticEidosValueNULL)->AddInt_OSN("ncol", gStaticEidosValueNULL));
 
 		
 		// ************************************************************************************

--- a/eidos/eidos_functions.h
+++ b/eidos/eidos_functions.h
@@ -225,6 +225,7 @@ EidosValue_SP Eidos_ExecuteFunction_rbind(const std::vector<EidosValue_SP> &p_ar
 EidosValue_SP Eidos_ExecuteFunction_t(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_upperTri(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_lowerTri(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
+EidosValue_SP Eidos_ExecuteFunction_diag(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 
 
 #pragma mark -

--- a/eidos/eidos_functions.h
+++ b/eidos/eidos_functions.h
@@ -223,6 +223,8 @@ EidosValue_SP Eidos_ExecuteFunction_ncol(const std::vector<EidosValue_SP> &p_arg
 EidosValue_SP Eidos_ExecuteFunction_nrow(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_rbind(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 EidosValue_SP Eidos_ExecuteFunction_t(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
+EidosValue_SP Eidos_ExecuteFunction_upperTri(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
+EidosValue_SP Eidos_ExecuteFunction_lowerTri(const std::vector<EidosValue_SP> &p_arguments, EidosInterpreter &p_interpreter);
 
 
 #pragma mark -

--- a/eidos/eidos_functions_matrices.cpp
+++ b/eidos/eidos_functions_matrices.cpp
@@ -1020,13 +1020,13 @@ EidosValue_SP Eidos_ExecuteFunction_lowerTri(const std::vector<EidosValue_SP> &p
 			for (int64_t col_index = 0; col_index < ncols; ++col_index)
 			{
 				// Get 1D index from rows/cols
-				int64_t index = row_index * ncols + col_index;
+				int64_t index = col_index * nrows + row_index;
 				
 				// Initialize value to F
 				result->set_logical_no_check(false, (int)index);
 
 				// Set lower triangle values to T
-				if ( row_index <= col_index )
+				if ( row_index >= col_index )
 				{
 					result->set_logical_no_check(true, (int)index);
 				}
@@ -1040,13 +1040,13 @@ EidosValue_SP Eidos_ExecuteFunction_lowerTri(const std::vector<EidosValue_SP> &p
 			for (int64_t col_index = 0; col_index < ncols; ++col_index)
 			{
 				// Get 1D index from rows/cols
-				int64_t index = row_index * ncols + col_index;
+				int64_t index = col_index * nrows + row_index;
 
 				// Initialize value to F
 				result->set_logical_no_check(false, (int)index);
 
 				// Set lower triangle values to T
-				if ( row_index < col_index )
+				if ( row_index > col_index )
 				{
 					result->set_logical_no_check(true, (int)index);
 				}
@@ -1089,13 +1089,13 @@ EidosValue_SP Eidos_ExecuteFunction_upperTri(const std::vector<EidosValue_SP> &p
 			for (int64_t col_index = 0; col_index < ncols; ++col_index)
 			{
 				// Get 1D index from rows/cols
-				int64_t index = row_index * ncols + col_index;
+				int64_t index = col_index * nrows + row_index;
 
 				// Initialize value to F
 				result->set_logical_no_check(false, (int)index);
 
 				// Set upper triangle values to T
-				if ( row_index >= col_index )
+				if ( row_index <= col_index )
 				{
 					result->set_logical_no_check(true, (int)index);
 				}
@@ -1109,13 +1109,13 @@ EidosValue_SP Eidos_ExecuteFunction_upperTri(const std::vector<EidosValue_SP> &p
 			for (int64_t col_index = 0; col_index < ncols; ++col_index)
 			{
 				// Get 1D index from rows/cols
-				int64_t index = row_index * ncols + col_index;
+				int64_t index = col_index * nrows + row_index;
 
 				// Initialize value to F
 				result->set_logical_no_check(false, (int)index);
 
 				// Set upper triangle values to T
-				if ( row_index > col_index )
+				if ( row_index < col_index )
 				{
 					result->set_logical_no_check(true, (int)index);
 				}

--- a/eidos/eidos_functions_matrices.cpp
+++ b/eidos/eidos_functions_matrices.cpp
@@ -992,7 +992,143 @@ EidosValue_SP Eidos_ExecuteFunction_t(const std::vector<EidosValue_SP> &p_argume
 	return result_SP;
 }
 
+// (*)lowerTri(* x, [logical$ diag = F])
+EidosValue_SP Eidos_ExecuteFunction_lowerTri(const std::vector<EidosValue_SP> &p_arguments, __attribute__((unused)) EidosInterpreter &p_interpreter)
+{
+	EidosValue_SP result_SP(nullptr);
+	EidosValue *x_value = p_arguments[0].get();
+	eidos_logical_t diag = p_arguments[1].get()->LogicalAtIndex(0, nullptr);
+	
+	if (x_value->DimensionCount() != 2)
+		EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_lowerTri): in function lowerTri() x is not a matrix." << EidosTerminate(nullptr);
+	
+	const int64_t *dim = x_value->Dimensions();
+	int64_t nrows = dim[0];
+	int64_t ncols = dim[1];
+	
+	// Create new empty logical matrix
+	EidosValue_Logical *result = (new (gEidosValuePool->AllocateChunk()) 
+									EidosValue_Logical())->resize_no_initialize(nrows * ncols);
+	result_SP = EidosValue_SP(result);
 
+	// Iterate through result matrix and set lower triangle to T, remaining values to F
+	// If we want the diagonal elements included, need to include them in our condition, row idx <= col idx
+	if (diag)
+	{
+		for (int64_t row_index = 0; row_index < nrows; ++row_index)
+		{
+			for (int64_t col_index = 0; col_index < ncols; ++col_index)
+			{
+				// Get 1D index from rows/cols
+				int64_t index = row_index * ncols + col_index;
+				
+				// Initialize value to F
+				result->set_logical_no_check(false, (int)index);
+
+				// Set lower triangle values to T
+				if ( row_index <= col_index )
+				{
+					result->set_logical_no_check(true, (int)index);
+				}
+			}
+		}
+	} 
+	else 
+	{
+		for (int64_t row_index = 0; row_index < nrows; ++row_index)
+		{
+			for (int64_t col_index = 0; col_index < ncols; ++col_index)
+			{
+				// Get 1D index from rows/cols
+				int64_t index = row_index * ncols + col_index;
+
+				// Initialize value to F
+				result->set_logical_no_check(false, (int)index);
+
+				// Set lower triangle values to T
+				if ( row_index < col_index )
+				{
+					result->set_logical_no_check(true, (int)index);
+				}
+			}
+		}
+	}
+
+	// Apply dimension attributes and return
+	const int64_t dim_buf[2] = {nrows, ncols};
+	result->SetDimensions(2, dim_buf);
+	
+	return result_SP;
+}
+
+// (*)lowerTri(* x, [logical$ diag = F])
+EidosValue_SP Eidos_ExecuteFunction_upperTri(const std::vector<EidosValue_SP> &p_arguments, __attribute__((unused)) EidosInterpreter &p_interpreter)
+{
+	EidosValue_SP result_SP(nullptr);
+	EidosValue *x_value = p_arguments[0].get();
+	eidos_logical_t diag = p_arguments[1].get()->LogicalAtIndex(0, nullptr);
+	
+	if (x_value->DimensionCount() != 2)
+		EIDOS_TERMINATION << "ERROR (Eidos_ExecuteFunction_upperTri): in function upperTri() x is not a matrix." << EidosTerminate(nullptr);
+	
+	const int64_t *dim = x_value->Dimensions();
+	int64_t nrows = dim[0];
+	int64_t ncols = dim[1];
+	
+	// Create new empty logical matrix
+	EidosValue_Logical *result = (new (gEidosValuePool->AllocateChunk()) 
+									EidosValue_Logical())->resize_no_initialize(nrows * ncols);
+	result_SP = EidosValue_SP(result);
+
+	// Iterate through result matrix and set lower triangle to T, remaining values to F
+	// If we want the diagonal elements included, need to include them in our condition, row idx >= col idx
+	if (diag)
+	{
+		for (int64_t row_index = 0; row_index < nrows; ++row_index)
+		{
+			for (int64_t col_index = 0; col_index < ncols; ++col_index)
+			{
+				// Get 1D index from rows/cols
+				int64_t index = row_index * ncols + col_index;
+
+				// Initialize value to F
+				result->set_logical_no_check(false, (int)index);
+
+				// Set upper triangle values to T
+				if ( row_index >= col_index )
+				{
+					result->set_logical_no_check(true, (int)index);
+				}
+			}
+		}
+	} 
+	else 
+	{
+		for (int64_t row_index = 0; row_index < nrows; ++row_index)
+		{
+			for (int64_t col_index = 0; col_index < ncols; ++col_index)
+			{
+				// Get 1D index from rows/cols
+				int64_t index = row_index * ncols + col_index;
+
+				// Initialize value to F
+				result->set_logical_no_check(false, (int)index);
+
+				// Set upper triangle values to T
+				if ( row_index > col_index )
+				{
+					result->set_logical_no_check(true, (int)index);
+				}
+			}
+		}
+	}
+
+	// Apply dimension attributes and return
+	const int64_t dim_buf[2] = {nrows, ncols};
+	result->SetDimensions(2, dim_buf);
+	
+	return result_SP;
+}
 
 
 


### PR DESCRIPTION
Hi @bhaller,

Recently I needed to extract the upper triangle from a symmetric matrix, but found that the Eidos code to do so was a bit clunky and slow with larger matrices. So I implemented some functions in C which are faster and more user-friendly.
```upperTri``` and ```lowerTri``` work in exactly the same way as in R: you specify an input matrix ```x```, and an optional argument for whether you want to include diagonal elements in your triangle or not. The default is to exclude them. The output is a logical matrix with the same dimensionality as ```x```. The ```true``` elements in the output are the upper/lower elements, depending on the function called.
You can then subset your input matrix by the upper/lower triangle to extract those values:
```
// Eidos
// Generate 4x4 input matrix
input = matrix(1:16), 4);
input
/*
     [,0] [,1] [,2] [,3]
[0,]    1    5    9   13
[1,]    2    6   10   14
[2,]    3    7   11   15
[3,]    4    8   12   16
*/

// Get upper triangle without diagonal entries
ut = upperTri(input);

// Extract diagonals
input[c(ut)];    // c() needed because we can't subset by matrices yet
// Output: 5 9 10 13 14 15
```
vs the R functionality
```
## R
## Generate 4x4 input matrix
input <- matrix(1:16), 4)
input

#      [,1] [,2] [,3] [,4]
# [1,]    1    5    9   13
# [2,]    2    6   10   14
# [3,]    3    7   11   15
# [4,]    4    8   12   16

## Get upper triangle without diagonal entries
ut <- upper.tri(input)

## Extract diagonals
input[ut]    ## no c() necessary 
# Output: 5 9 10 13 14 15
```

Another feature I could add is the ```diag``` function from R: however it has different behaviour, extracting the diagonal values directly rather than providing a logical matrix. Would be keen to hear your thoughts on whether I should replicate the R behaviour or keep it consistent with ```upperTri``` and ```lowerTri```.

Cheers,
Nick