### PR TITLE
Use CMake to perform installation, and RPM macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,9 +348,9 @@ else()
         target_link_libraries(${TARGET_NAME} PUBLIC Qt5::Widgets Qt5::Core Qt5::Gui OpenGL::GL gsl tables eidos_zlib gnu )
     else()
 	    target_link_libraries( ${TARGET_NAME} PUBLIC Qt5::Widgets Qt5::Core Qt5::Gui OpenGL::GL gsl tables eidos_zlib )
-
-	    install(DIRECTORY data/ DESTINATION share)
-    endif()
+        # Install icons and desktop files to the data root directory (usually /usr/local/share, or /usr/share).
+	    install(DIRECTORY data/ TYPE DATA)
+    endif() 
 endif()
 install(TARGETS ${TARGET_NAME} DESTINATION bin)
 endif(BUILD_SLIMGUI)

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,6 +1,14 @@
+# Cross-distribution SLiM RPM spec.
+# Defines:
+%if %{defined suse_version}
+%define qt5 libqt5
+%else
+%define qt5 qt5
+%endif
+
 Name:           SLiM
-Version:        4.0.1
-Release:        2%{?dist}
+Version:        4.1
+Release:        1%{?dist}
 Summary:        an evolutionary simulation framework
 
 License:        GPLv3+
@@ -10,6 +18,7 @@ Source0:        https://github.com/MesserLab/SLiM/archive/v%{version}.tar.gz
 # Prevent users of the Copr repository from using Simple Login Manager, due to binary file name conflict.
 Conflicts:      slim
 
+# This paragraph of the spec file is old and delicate.
 BuildRequires:  cmake
 # openSUSE Build Requires
 %if %{defined suse_version}
@@ -26,23 +35,8 @@ BuildRequires:  libappstream-glib
 %endif
 ExclusiveArch:  x86_64
 
-# Fedora: these package versions are those that COPR is building against, and thus if
-# they change because of point releases in Qt5, the RPMs need to be rebuilt and deployed.
-# Qt is weird and doesn't allow older software to be used if a newer point release is
-# installed on the system.
-%if 0%{?fedora}
-Requires: qt5-qtbase >= 5.13.2
-%endif
-
-# Conditonal requires for RHEL (and CentOS)
-%if 0%{?rhel}
-Requires: qt5-qtbase >= 5.12.5
-%endif
-
-# Conditional requires for openSUSE and SLE.
-%if %{defined suse_version}
-Requires: libqt5-qtbase >= 5.12.7
-%endif
+# RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
+Requires: %{qt5}-qtbase >= 5.15.1
 
 %description
 SLiM is an evolutionary simulation framework that combines a powerful engine for
@@ -56,36 +50,33 @@ Linux for easy simulation set-up, interactive runtime control, and dynamical
 visualization of simulation output.
 
 %prep
-tar -xf ../SOURCES/v%{version}.tar.gz
+%setup -q
 
 %build
-# NOTE: is the relative path required when using the cmake macro due to the above source prep-style?
-%cmake -DBUILD_SLIMGUI=ON #./SLiM-%version}/
+%cmake -DBUILD_SLIMGUI=ON
 %cmake_build
 
 %install
 %cmake_install
 
-%check
-appstream-util validate-relax --nonet %{buildroot}/usr/share/metainfo/org.messerlab.slimgui.appdata.xml
-
 %files
-/usr/bin/eidos
-/usr/bin/slim
-/usr/bin/SLiMgui
-/usr/share/applications/org.messerlab.slimgui.desktop
-/usr/share/icons/hicolor/scalable/apps/org.messerlab.slimgui.svg
-/usr/share/icons/hicolor/scalable/mimetypes/text-slim.svg
-/usr/share/icons/hicolor/symbolic/apps/org.messerlab.slimgui-symbolic.svg
-/usr/share/metainfo/org.messerlab.slimgui.appdata.xml
-/usr/share/metainfo/org.messerlab.slimgui.metainfo.xml
-/usr/share/mime/packages/org.messerlab.slimgui-mime.xml
-
-%post
-update-mime-database -n /usr/share/mime/
-xdg-mime install --mode system /usr/share/mime/packages/org.messerlab.slimgui-mime.xml
+%{_bindir}/eidos
+%{_bindir}/slim
+%{_bindir}/SLiMgui
+%{_datadir}/applications/org.messerlab.slimgui.desktop
+%{_datadir}/icons/hicolor/scalable/apps/org.messerlab.slimgui.svg
+%{_datadir}/icons/hicolor/scalable/mimetypes/text-slim.svg
+%{_datadir}/icons/hicolor/symbolic/apps/org.messerlab.slimgui-symbolic.svg
+%{_datadir}/metainfo/org.messerlab.slimgui.appdata.xml
+%{_datadir}/metainfo/org.messerlab.slimgui.metainfo.xml
+%{_datadir}/mime/packages/org.messerlab.slimgui-mime.xml
 
 %changelog
+* Mon Dec 4 2023 Bryce Carson <bryce.a.carson@gmail.com> - 4.1-1
+- Final candidate 1 for 4.1 release
+- CMake install of package desktop environment data properly implemented
+- RPM macros adopted
+
 * Tue Sep 27 2022 Bryce Carson <bryce.a.carson@gmail.com> - 4.0.1-2
 - `CMakeLists.txt` improved, so the installation section of the RPM is now simplified.
 - Data files now exist in `data/`, rather than in the root folder of the software.

--- a/data/metainfo/org.messerlab.slimgui.appdata.xml
+++ b/data/metainfo/org.messerlab.slimgui.appdata.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>org.messerlab.slimgui</id>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <name>SLiMgui</name>
+  <launchable type="desktop-id">org.messerlab.slimgui.desktop</launchable>
   <summary>Evolutionary simulation framework</summary>
-  <url type="homepage">https://messerlab.org/slim/</url>
   <description>
     <p>
       SLiM is an evolutionary simulation framework that combines a powerful engine for population genetic simulations with the capability of modeling arbitrarily complex evolutionary scenarios. Simulations are configured via the integrated Eidos scripting language that allows interactive control over practically every aspect of the simulated evolutionary scenarios. The underlying individual-based simulation engine is highly optimized to enable modeling of entire chromosomes in large populations. We also provide a graphical user interface on macOS and Linux for easy simulation set-up, interactive runtime control, and dynamical visualization of simulation output.
@@ -22,6 +22,6 @@
   <developer_name>Ben Haller</developer_name>
   <content_rating type="oars-1.0" />
   <releases>
-      <release version="v4.0.1" date="2022-09-13" type="stable"/>
+      <release version="v4.1" date="2023-12-01" type="stable"/>
   </releases>
 </component>

--- a/data/metainfo/org.messerlab.slimgui.metainfo.xml
+++ b/data/metainfo/org.messerlab.slimgui.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>org.messerlab.slim</id>
+  <id>org.messerlab.slimgui</id>
   
   <name>SLiM</name>
   <summary>Evolutionary simulation framework for population genetics</summary>
@@ -26,6 +26,6 @@
   <developer_name>Ben Haller</developer_name>
   <content_rating type="oars-1.0" />
   <releases>
-    <release version="v4.0.1" date="2022-09-13" type="stable"/>
+    <release version="v4.1" date="2023-12-01" type="stable"/>
 </releases>
 </component>


### PR DESCRIPTION
Hi Ben,

This PR updates the RPM spec file for the 4.1 release, adopts recommended RPM macros rather than hard-coding things (though that did appear robust in the past), and makes CMake capable of installing SLiMgui, slim, and eidos with desktop integration (which simplifies the role of RPM and makes the spec file more maintainable).

It didn't cross my mind until now, but the following should work beautifully and provide desktop integration on Linux platforms when building from source and should also be integrated into the manual's installation instructions:

```sh
cmake -D BUILD_SLIMGUI=ON
make
make install # This line, on Linux, will now *also* install Desktop integration files.
```