### PR TITLE
Add contig header to VCF

### DIFF
--- a/core/genome.cpp
+++ b/core/genome.cpp
@@ -1589,6 +1589,7 @@ void Genome::PrintGenomes_VCF(std::ostream &p_out, std::vector<Genome *> &p_geno
 	if (p_output_nonnucs && p_nucleotide_based)
 		p_out << "##INFO=<ID=NONNUC,Number=0,Type=Flag,Description=\"Non-nucleotide-based\">" << std::endl;
 	p_out << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << std::endl;
+	p_out << "##contig=<ID=1,URL=https://github.com/MesserLab/SLiM>" << std::endl;
 	p_out << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT";
 	
 	for (slim_popsize_t s = 0; s < sample_size; s++)


### PR DESCRIPTION
Hi!

Thanks for this amazing software! I have a question related to VCF files. Is there any reason not include the contig header in the VCF file?  According to the [VCF spec](https://samtools.github.io/hts-specs/VCFv4.1.pdf), "it is highly recommended (but not required) that the header include tags describing the contigs referred to in the VCF file".

For example, I found it necessary when filtering the VCF file using bcftools. I made a simple example: [model_vcf.txt](https://github.com/MesserLab/SLiM/files/14164517/model_vcf.txt)


```bash
slim model_vcf.txt
 # creates results.vcf 
bcftools view --samples i1,i2 < results.vcf
```

The previous chunk of code gives me the error:

```bash
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  i1      i2
[W::vcf_parse] Contig '1' is not defined in the header. (Quick workaround: index the file with tabix.)
Undefined tags in the header, cannot proceed in the sample subset mode.
```

As far as I understand from the source code, the [CHROM column is fixed to be 1)](https://github.com/MesserLab/SLiM/blob/aefd55fc534055759e6f386759073a9c04a965ba/core/genome.cpp#L1685-L1686). 

Would not the PR I made do the trick (although maybe it is a bit pretentious to say that a single line is a PR)?I built it locally (using the code snipped from the TO_DO file) and do some minimal testing:

```bash
mkdir build
cd build
cmake ..
make
./slim model_vcf.txt # creates results.vcf 
bcftools view --samples i1,i2 < results.vcf
```

I'm not sure if it is a breaking change, but the tests from the command line still works. I tried:

```bash
./slim -testEidos
SUCCESS count: 6885
```
and
```bash
./slim -testEidos
SUCCESS count: 36435
```

Please, let me know if I misunderstood something. 

Best,
Curro

