### PR TITLE
Use make test in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,9 +123,7 @@ jobs:
       - name: Test (Debug)
         run: |
           cd Debug
-          ./eidos -testEidos
-          ./slim -testEidos
-          ./slim -testSLiM
+          make test
 
       - name: Build (Release)
         run: |
@@ -137,9 +135,7 @@ jobs:
       - name: Test (Release)
         run: |
           cd Release
-          ./eidos -testEidos
-          ./slim -testEidos
-          ./slim -testSLiM
+          make test
 
       - name: Treesequence tests
         run: |
@@ -313,9 +309,7 @@ jobs:
       - name: Test (Release)
         run: |
           cd Release
-          ./eidos -testEidos
-          ./slim -testEidos
-          ./slim -testSLiM
+          make test
 
       - name: Treesequence tests
         shell: bash -l {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,8 +433,14 @@ add_test(
   NAME testSLiM
   COMMAND ${TARGET_NAME_SLIM} -testSLiM
 )
-# test Eidos
+# test Eidos from SLiM
 add_test(
-  NAME testEidos
+  NAME testEidosSLiM
   COMMAND ${TARGET_NAME_SLIM} -testEidos
+)
+
+# test Eidos from Eidos
+add_test(
+  NAME testEidosEidos
+  COMMAND ${TARGET_NAME_EIDOS} -testEidos
 )


### PR DESCRIPTION
As we agreed yesterday, here's a minimal PR using `make test` in the CI. I have also modified the Cmake file to also run the Eidos test suite from the Eidos executable (to match previous CI). 