### PR TITLE
Move to nodefault conda channel in CI  

### DIFF
--- a/treerec/tests/environment.yml
+++ b/treerec/tests/environment.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - tskit >= 0.4.1
   - msprime >= 1.2.0


### PR DESCRIPTION
Hi again!
I've recently come across on social media about some issues with the default channel of Anaconda and its license for academic usage (that I'm not sure I understand). 

https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/

https://www.linkedin.com/posts/pzwang_hi-everyone-recently-there-has-been-discussion-activity-7229549723462905856-rQH-?utm_source=share&utm_medium=member_desktop

Unlike "conda-forge"  or "bioconda" (which are community-maintained), the "default" channel is maintained by Anaconda which generates revenue by selling access to it to companies. If I understood correctly, big organizations (>200) may have to pay unless they are exempt (see https://legal.anaconda.com/policies/)


I thought of the PR I made about the CI a few weeks ago and I took a look. Before my changes, CI was using conda which, as far as I know, has hardcoded the "default" Anaconda channel. My changes moved to mamba but still relied on the "default" channel (see the YAML file). 

It seems like a good idea to me to stop using the channel, as it is conditionally free for non-profit organizations (or that's what I understood) and  I don't think is actually needed at all (or even used right now, as conda-forge has a higher priority)
