### PR TITLE
Update SLiM.spec to work with Qt 6 for Fedora and openSUSE

### DIFF
--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,4 +1,3 @@
-
 # Cross-distribution SLiM RPM spec.
 %if %{defined suse_version}
 %if 0%{?suse_version} < 1600
@@ -120,7 +119,11 @@ cmake --install %_vpath_builddir --prefix %{buildroot}/usr
 %{_datadir}/mime/packages/org.messerlab.slimgui-mime.xml
 
 %changelog
-* Mon Sep 02 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3.-1
+* Sun Sep 15 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3-2
+- Significant work has been invested into debugging the build of RHEL 8 on COPR. For whatever reason, since 4.0.1-1, we were unable to build on RHEL 8 (or perhaps it was EPEL 8?). Regardless, the ability to build on RHEL 8 and EPEL 8 has been achieved or restored, using conditionals which check what distribution the build is occuring on. These conditionals check the distribution using the defined RPM macros, a reliable system that the operating systems try not to step on each others toes; it'd be nicer if CentOS didn't call itself RHEL, though, but CentOS purposefully tries to be "bug-compatible" (if I recall) with RHEL, yet be slightly upstream of it with RHEL. The buildroot (which is the installation prefix within the CHROOT) and the source and build directories must be manually specified when building on RHEL 8 or EPEL 8 systems (which is RHEL 8 + EPEL [the extra packages for enterprise linux repository] for RHEL 8). I don't know what changed amongst the macros, if anything ever did change, but with 4.0.1-1 we were able to build for EPEL 8 two years ago, and then we weren't when I tried however long ago that issue four-hundred and forty cropped up. This has been resolved with the use of conditionals in the RPM preprocessor (do recall that "if" is not actually a macro) and RPM macros.
+- Conditionals and macros are used to decide whether to use Qt 6 or Qt 5.
+
+* Mon Sep 02 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3-1
 - Changes to the package have occurred. See the following points.
 - Further version checks for various distributions are introduced to allow cross-distribution packaging and building against Qt5 or Qt6, appropriate to the platform.
 - An attempt to fix issue 440 is made

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -102,7 +102,7 @@ cd %_vpath_builddir
 
 %install
 %if 0%{?rhel} == 8
-cmake --install %_vpath_builddir --prefix %{buildroot}
+cmake --install %_vpath_builddir --prefix %{buildroot}/usr
 %else
 %cmake_install
 %endif

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -83,6 +83,10 @@ mkdir outputbins
 %endif
 
 %build
+%if %_vpath_builddir == %_vpath_srcdir
+%(mkdir builddir)
+%global %_vpath_builddir builddir
+%endif
 %cmake -DBUILD_SLIMGUI=ON
 %cmake_build
 

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -80,25 +80,21 @@ visualization of simulation output.
 
 %build
 %if 0%{?rhel} == 8
-%echo "========= PRE DUMP ========="
-%echo "Enabling %{?trace:%trace}..."
-%echo "Dumping using the %dump macro..."
-%echo "Dumping using the rpm commands documented in the RHEL 8 Packaging and Distributing Software documentation..."
-# see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/packaging_and_distributing_software/index#displaying-the-built-in-macros_more-on-macros
+echo "========= PRE DUMP ========="
 rpm --showrc
 rpm -ql rpm
-%echo "========= POST DUMP ========="
+echo "========= POST DUMP ========="
 
 %if "%_vpath_builddir" != "%_vpath_srcdir"
-%{echo current directory: %(pwd)}
-%{echo source directory: %_vpath_srcdir}
-%{echo build directory: %_vpath_builddir}
+echo "current directory: %(pwd)"
+echo "source directory: %_vpath_srcdir"
+echo "build directory: %_vpath_builddir"
 mkdir -p %_vpath_builddir
-cd %_vpath_builddir
 %else
 %{warn "The build directory is the same as the source directory on RHEL 8!"}
 %endif
 
+## Tell CMake where the source directory and the build directory are, directly.
 %cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
 
 %else

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -80,11 +80,6 @@ visualization of simulation output.
 
 %build
 %if 0%{?rhel} == 8
-echo "========= PRE DUMP ========="
-rpm --showrc
-rpm -ql rpm
-echo "========= POST DUMP ========="
-
 %if "%_vpath_builddir" != "%_vpath_srcdir"
 echo "current directory: %(pwd)"
 echo "source directory: %_vpath_srcdir"
@@ -96,7 +91,7 @@ mkdir -p %_vpath_builddir
 
 ## Tell CMake where the source directory and the build directory are, directly.
 %cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
-
+cd %_vpath_builddir
 %else
 # rpmbuild is not running on RHEL 8
 %cmake -DBUILD_SLIMGUI=ON

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -80,14 +80,14 @@ visualization of simulation output.
 
 %build
 %if 0%{?rhel} == 8
-%echo "Enabling trace..."
-%trace
-%echo "Dumping using the %%dump macro..."
-%dump
+%echo "========= PRE DUMP ========="
+%echo "Enabling %{?trace:%trace}..."
+%echo "Dumping using the %dump macro..."
 %echo "Dumping using the rpm commands documented in the RHEL 8 Packaging and Distributing Software documentation..."
 # see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/packaging_and_distributing_software/index#displaying-the-built-in-macros_more-on-macros
 rpm --showrc
 rpm -ql rpm
+%echo "========= POST DUMP ========="
 
 %if "%_vpath_builddir" != "%_vpath_srcdir"
 %{echo current directory: %(pwd)}

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,14 +1,14 @@
 # Cross-distribution SLiM RPM spec.
 %if %{defined suse_version}
 %if 0%{?suse_version} < 1600
-%define qt libqt5
+%global qtNameAndVersion libqt5
 %else
-%define qt libqt6
+%global qtNameAndVersion qt6
 %endif
 %endif
 
 %if 0%{?fedora} >= 39
-%define qt qt6
+%global qtNameAndVersion qt6
 %endif
 
 Name:           SLiM
@@ -32,22 +32,23 @@ BuildRequires:  Mesa-libGL-devel
 BuildRequires:  gcc-c++
 BuildRequires:  appstream-glib-devel
 %if 0%{?suse_version} < 1600
-BuildRequires:  %{qt}-qtbase-devel
+BuildRequires:  %{qtNameAndVersion}-qtbase-devel
 %endif
-%if 0%{?suse_version} > 1600 # only Tumbleweed officially supports Qt6
-BuildRequires:  %{qt}-qtbase-devel
+%if 0%{?suse_version} > 1600
+# only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
+BuildRequires:  %{qtNameAndVersion}-base-devel
 %endif
 %else
-BuildRequires:  %{qt}-qtbase-devel
+BuildRequires:  %{qtNameAndVersion}-qtbase-devel
 BuildRequires:  libappstream-glib
 %endif
 ExclusiveArch:  x86_64
 
 # RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
 %if 0%{?rhel} == 8
-Requires: %{qt}-qtbase >= 5.15.1
+Requires: %{qtNameAndVersion}-qtbase >= 5.15.1
 %else
-Requries: %{qt}-qtbase
+Requires: %{qtNameAndVersion}-qtbase
 %endif
 
 %description
@@ -89,7 +90,7 @@ mkdir outputbins
 %{_datadir}/mime/packages/org.messerlab.slimgui-mime.xml
 
 %changelog
-* Mon Sep 2 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3.-1
+* Mon Sep 02 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3.-1
 - Changes to the package have occurred. See the following points.
 - Further version checks for various distributions are introduced to allow cross-distribution packaging and building against Qt5 or Qt6, appropriate to the platform.
 - An attempt to fix issue 440 is made
@@ -108,7 +109,7 @@ mkdir outputbins
 - No changes to the package have been made since the last release.
 - Fix for a crashing bug under certain conditions.
 
-* Thu Mar 20 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.2-1
+* Wed Mar 20 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.2-1
 - No changes to the package have been made since the last release. See the SLiM release notes on GitHub for information about changes to the packaged software.
 
 * Mon Dec 4 2023 Bryce Carson <bryce.a.carson@gmail.com> - 4.1-1

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -16,7 +16,8 @@
 %endif
 
 %if %{defined rhel}
-%if 0%{?rhel} > 8
+%if 0%{?epel} >= 9
+# qt6 is only available through EPEL on RHEL 9 and higher
 %global qtNameAndVersion qt6
 %else
 %global qtNameAndVersion qt5
@@ -45,12 +46,12 @@ BuildRequires:  gcc-c++
 BuildRequires:  appstream-glib-devel
 %if 0%{?suse_version} < 1600
 BuildRequires:  %{qtNameAndVersion}-qtbase-devel
-%endif
-%if 0%{?suse_version} > 1600
+%else
 # only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
 BuildRequires:  %{qtNameAndVersion}-base-devel
 %endif
 %else
+# if not on openSUSE
 BuildRequires:  %{qtNameAndVersion}-qtbase-devel
 BuildRequires:  libappstream-glib
 %endif
@@ -58,7 +59,7 @@ ExclusiveArch:  x86_64
 
 # RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
 %if 0%{?rhel} == 8
-Requires: %{qtNameAndVersion}-qtbase >= 5.15.1
+Requires: qt5-qtbase >= 5.15.1
 %else
 Requires: %{qtNameAndVersion}-qtbase
 %endif
@@ -76,18 +77,13 @@ visualization of simulation output.
 
 %prep
 %setup -q
-# attempt to sidestep issue 440
-%if 0%{?rhel} == 8
-mkdir outputbins
-%define _vpath_builddir outputbins
-%endif
 
 %build
 %if 0%{?rhel} == 8
 %if "%_vpath_builddir" == "%_vpath_srcdir"
 %(mkdir builddir)
 %{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
-%global %_vpath_builddir builddir
+%global _vpath_builddir builddir
 %endif
 %endif
 %cmake -DBUILD_SLIMGUI=ON

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -79,15 +79,14 @@ visualization of simulation output.
 %setup -q
 
 %build
-%cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
-
 %if 0%{?rhel} == 8 && "%_vpath_builddir" != "%_vpath_srcdir"
 mkdir -p %_vpath_builddir
 cd %_vpath_builddir
 %else
-%error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
+%error "The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"
 %endif
 
+%cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
 %cmake_build
 
 %install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,3 +1,4 @@
+
 # Cross-distribution SLiM RPM spec.
 %if %{defined suse_version}
 %if 0%{?suse_version} < 1600

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -32,22 +32,22 @@ BuildRequires:  Mesa-libGL-devel
 BuildRequires:  gcc-c++
 BuildRequires:  appstream-glib-devel
 %if 0%{?suse_version} < 1600
-BuildRequires:  %qt-qtbase-devel
+BuildRequires:  %{qt}-qtbase-devel
 %endif
 %if 0%{?suse_version} > 1600 # only Tumbleweed officially supports Qt6
-BuildRequires:  %qt-qtbase-devel
+BuildRequires:  %{qt}-qtbase-devel
 %endif
 %else
-BuildRequires:  %qt-qtbase-devel
+BuildRequires:  %{qt}-qtbase-devel
 BuildRequires:  libappstream-glib
 %endif
 ExclusiveArch:  x86_64
 
 # RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
 %if 0%{?rhel} == 8
-Requires: %{qt5}-qtbase >= 5.15.1
+Requires: %{qt}-qtbase >= 5.15.1
 %else
-Requries: %qt-qtbase
+Requries: %{qt}-qtbase
 %endif
 
 %description

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -79,11 +79,21 @@ visualization of simulation output.
 %setup -q
 
 %build
+%define errmsg The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
 %if 0%{?rhel} == 8 && "%_vpath_builddir" == "%_vpath_srcdir"
-%error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
+%error %errmsg
 %endif
 %cmake -DBUILD_SLIMGUI=ON
+%if 0%{?rhel} == 8 && "%_vpath_builddir" != "%_vpath_srcdir"
+%if "." == "%_vpath_builddir"
+%error %errmsg
+%endif
+cd %_vpath_builddir
+%{lua string.gsub(%{macrobody %{cmake_build}}, "--build .", "--build %_vpath_builddir")}
+%else
+# Not on RHEL 8
 %cmake_build
+%endif
 
 %install
 %cmake_install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -83,9 +83,12 @@ mkdir outputbins
 %endif
 
 %build
-%if %_vpath_builddir == %_vpath_srcdir
+%if 0%{?rhel} == 8
+%if "%_vpath_builddir" == "%_vpath_srcdir"
 %(mkdir builddir)
+%{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
 %global %_vpath_builddir builddir
+%endif
 %endif
 %cmake -DBUILD_SLIMGUI=ON
 %cmake_build

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,27 +1,27 @@
 # Cross-distribution SLiM RPM spec.
 %if %{defined suse_version}
-%if 0%{?suse_version} < 1600
-%global qtNameAndVersion libqt5
-%else
-%global qtNameAndVersion qt6
-%endif
+  %if 0%{?suse_version} < 1600
+    %global qtNameAndVersion libqt5
+  %else
+    %global qtNameAndVersion qt6
+  %endif
 %endif
 
 %if %{defined fedora}
-%if 0%{?fedora} >= 39
-%global qtNameAndVersion qt6
-%else
-%global qtNameAndVersion qt5
-%endif
+  %if 0%{?fedora} >= 39
+    %global qtNameAndVersion qt6
+  %else
+    %global qtNameAndVersion qt5
+  %endif
 %endif
 
 %if %{defined rhel}
-%if 0%{?epel} >= 9
-# qt6 is only available through EPEL on RHEL 9 and higher
-%global qtNameAndVersion qt6
-%else
-%global qtNameAndVersion qt5
-%endif
+  %if 0%{?epel} >= 9
+    # qt6 is only available through EPEL on RHEL 9 and higher
+    %global qtNameAndVersion qt6
+  %else
+    %global qtNameAndVersion qt5
+  %endif
 %endif
 
 Name:           SLiM
@@ -40,28 +40,28 @@ Conflicts:      slim
 BuildRequires:  cmake
 # openSUSE Build Requires
 %if %{defined suse_version}
-BuildRequires:  glew-devel
-BuildRequires:  Mesa-libGL-devel
-BuildRequires:  gcc-c++
-BuildRequires:  appstream-glib-devel
-%if 0%{?suse_version} < 1600
-BuildRequires:  %{qtNameAndVersion}-qtbase-devel
+  BuildRequires:  glew-devel
+  BuildRequires:  Mesa-libGL-devel
+  BuildRequires:  gcc-c++
+  BuildRequires:  appstream-glib-devel
+  %if 0%{?suse_version} < 1600
+    BuildRequires:  %{qtNameAndVersion}-qtbase-devel
+  %else
+    # only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
+    BuildRequires:  %{qtNameAndVersion}-base-devel
+  %endif
 %else
-# only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
-BuildRequires:  %{qtNameAndVersion}-base-devel
-%endif
-%else
-# if not on openSUSE
-BuildRequires:  %{qtNameAndVersion}-qtbase-devel
-BuildRequires:  libappstream-glib
+  # if not on openSUSE
+  BuildRequires:  %{qtNameAndVersion}-qtbase-devel
+  BuildRequires:  libappstream-glib
 %endif
 ExclusiveArch:  x86_64
 
 # RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
 %if 0%{?rhel} == 8
-Requires: qt5-qtbase >= 5.15.1
+  Requires: qt5-qtbase >= 5.15.1
 %else
-Requires: %{qtNameAndVersion}-qtbase
+  Requires: %{qtNameAndVersion}-qtbase
 %endif
 
 %description
@@ -79,21 +79,16 @@ visualization of simulation output.
 %setup -q
 
 %build
-%define errmsg The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
-%if 0%{?rhel} == 8 && "%_vpath_builddir" == "%_vpath_srcdir"
-%error %errmsg
-%endif
-%cmake -DBUILD_SLIMGUI=ON
+%cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
+
 %if 0%{?rhel} == 8 && "%_vpath_builddir" != "%_vpath_srcdir"
-%if "." == "%_vpath_builddir"
-%error %errmsg
-%endif
-cd %_vpath_builddir
-%{lua string.gsub(%{macrobody %{cmake_build}}, "--build .", "--build %_vpath_builddir")}
+  mkdir -p %_vpath_builddir
+  cd %_vpath_builddir
 %else
-# Not on RHEL 8
-%cmake_build
+  %error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
 %endif
+
+%cmake_build
 
 %install
 %cmake_install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -79,16 +79,10 @@ visualization of simulation output.
 %setup -q
 
 %build
-%if 0%{?rhel} == 8
-%if "%_vpath_builddir" == "%_vpath_srcdir"
-%(mkdir builddir)
-%{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
-%global _vpath_builddir builddir
+%if 0%{?rhel} == 8 && "%_vpath_builddir" == "%_vpath_srcdir"
+%error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
 %endif
-%define sourceDirectory -S %{_vpath_srcdir}
-%define buildDirectory -B %{_vpath_builddir}
-%endif
-%cmake %{?sourceDirectory:%sourceDirectory} %{?buildDirectory:%buildDirectory} -DBUILD_SLIMGUI=ON
+%cmake -DBUILD_SLIMGUI=ON
 %cmake_build
 
 %install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -79,11 +79,26 @@ visualization of simulation output.
 %setup -q
 
 %build
-%if 0%{?rhel} == 8 && "%_vpath_builddir" != "%_vpath_srcdir"
+%if 0%{?rhel} == 8
+%echo "Enabling trace..."
+%trace
+%echo "Dumping using the %%dump macro..."
+%dump
+%echo "Dumping using the rpm commands documented in the RHEL 8 Packaging and Distributing Software documentation..."
+# see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/packaging_and_distributing_software/index#displaying-the-built-in-macros_more-on-macros
+rpm --showrc
+rpm -ql rpm
+
+%if "%_vpath_builddir" != "%_vpath_srcdir"
+%{echo current directory: %(pwd)}
+%{echo source directory: %_vpath_srcdir}
+%{echo build directory: %_vpath_builddir}
 mkdir -p %_vpath_builddir
 cd %_vpath_builddir
 %else
-%{error "The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"}
+%{warn "The build directory is the same as the source directory on RHEL 8!"}
+%endif
+
 %endif
 
 %cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -7,8 +7,20 @@
 %endif
 %endif
 
+%if %{defined fedora}
 %if 0%{?fedora} >= 39
 %global qtNameAndVersion qt6
+%else
+%global qtNameAndVersion qt5
+%endif
+%endif
+
+%if %{defined rhel}
+%if 0%{?rhel} > 8
+%global qtNameAndVersion qt6
+%else
+%global qtNameAndVersion qt5
+%endif
 %endif
 
 Name:           SLiM

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -85,8 +85,9 @@ visualization of simulation output.
 %{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
 %global _vpath_builddir builddir
 %endif
+%global sourceAndBuilddir "-S %{_vpath_srcdir} -B %{_vpath_builddir}"
 %endif
-%cmake -DBUILD_SLIMGUI=ON
+%cmake %{sourceAndBuilddir} -DBUILD_SLIMGUI=ON 
 %cmake_build
 
 %install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -101,7 +101,7 @@ cd %_vpath_builddir
 
 %install
 %if 0%{?rhel} == 8
-cmake --install %_vpath_builddir
+cmake --install %_vpath_builddir --prefix %{buildroot}
 %else
 %cmake_install
 %endif

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -100,7 +100,11 @@ cd %_vpath_builddir
 %cmake_build
 
 %install
+%if 0%{?rhel} == 8
+cmake --install %_vpath_builddir
+%else
 %cmake_install
+%endif
 
 %files
 %{_bindir}/eidos

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -85,8 +85,8 @@ visualization of simulation output.
 %{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
 %global _vpath_builddir builddir
 %endif
-%define sourceDirectory "-S %{_vpath_srcdir}"
-%define buildDirectory "-B %{_vpath_builddir}"
+%define sourceDirectory -S %{_vpath_srcdir}
+%define buildDirectory -B %{_vpath_builddir}
 %endif
 %cmake %{?sourceDirectory:%sourceDirectory} %{?buildDirectory:%buildDirectory} -DBUILD_SLIMGUI=ON
 %cmake_build

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -99,9 +99,13 @@ cd %_vpath_builddir
 %{warn "The build directory is the same as the source directory on RHEL 8!"}
 %endif
 
+%cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
+
+%else
+# rpmbuild is not running on RHEL 8
+%cmake -DBUILD_SLIMGUI=ON
 %endif
 
-%cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
 %cmake_build
 
 %install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -83,7 +83,7 @@ visualization of simulation output.
 mkdir -p %_vpath_builddir
 cd %_vpath_builddir
 %else
-%error "The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"
+%{error "The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"}
 %endif
 
 %cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -31,7 +31,7 @@ Summary:        an evolutionary simulation framework
 
 License:        GPLv3+
 URL:            https://messerlab.org/slim/
-Source0:        https://github.com/bryce-carson/SLiM/archive/v%{version}.tar.gz
+Source0:        https://github.com/MesserLab/SLiM/archive/v%{version}.tar.gz
 
 # Prevent users of the Copr repository from using Simple Login Manager, due to binary file name conflict.
 Conflicts:      slim

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -85,9 +85,10 @@ visualization of simulation output.
 %{error:"The build directory is the same as the source directory; even though that shouldn't be, it is what it is!"} 	
 %global _vpath_builddir builddir
 %endif
-%global sourceAndBuilddir "-S %{_vpath_srcdir} -B %{_vpath_builddir}"
+%define sourceDirectory "-S %{_vpath_srcdir}"
+%define buildDirectory "-B %{_vpath_builddir}"
 %endif
-%cmake %{sourceAndBuilddir} -DBUILD_SLIMGUI=ON 
+%cmake %{?sourceDirectory:%sourceDirectory} %{?buildDirectory:%buildDirectory} -DBUILD_SLIMGUI=ON
 %cmake_build
 
 %install

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -1,27 +1,27 @@
 # Cross-distribution SLiM RPM spec.
 %if %{defined suse_version}
-  %if 0%{?suse_version} < 1600
-    %global qtNameAndVersion libqt5
-  %else
-    %global qtNameAndVersion qt6
-  %endif
+%if 0%{?suse_version} < 1600
+%global qtNameAndVersion libqt5
+%else
+%global qtNameAndVersion qt6
+%endif
 %endif
 
 %if %{defined fedora}
-  %if 0%{?fedora} >= 39
-    %global qtNameAndVersion qt6
-  %else
-    %global qtNameAndVersion qt5
-  %endif
+%if 0%{?fedora} >= 39
+%global qtNameAndVersion qt6
+%else
+%global qtNameAndVersion qt5
+%endif
 %endif
 
 %if %{defined rhel}
-  %if 0%{?epel} >= 9
-    # qt6 is only available through EPEL on RHEL 9 and higher
-    %global qtNameAndVersion qt6
-  %else
-    %global qtNameAndVersion qt5
-  %endif
+%if 0%{?epel} >= 9
+# qt6 is only available through EPEL on RHEL 9 and higher
+%global qtNameAndVersion qt6
+%else
+%global qtNameAndVersion qt5
+%endif
 %endif
 
 Name:           SLiM
@@ -40,28 +40,28 @@ Conflicts:      slim
 BuildRequires:  cmake
 # openSUSE Build Requires
 %if %{defined suse_version}
-  BuildRequires:  glew-devel
-  BuildRequires:  Mesa-libGL-devel
-  BuildRequires:  gcc-c++
-  BuildRequires:  appstream-glib-devel
-  %if 0%{?suse_version} < 1600
-    BuildRequires:  %{qtNameAndVersion}-qtbase-devel
-  %else
-    # only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
-    BuildRequires:  %{qtNameAndVersion}-base-devel
-  %endif
+BuildRequires:  glew-devel
+BuildRequires:  Mesa-libGL-devel
+BuildRequires:  gcc-c++
+BuildRequires:  appstream-glib-devel
+%if 0%{?suse_version} < 1600
+BuildRequires:  %{qtNameAndVersion}-qtbase-devel
 %else
-  # if not on openSUSE
-  BuildRequires:  %{qtNameAndVersion}-qtbase-devel
-  BuildRequires:  libappstream-glib
+# only Tumbleweed officially supports Qt6; further, it's "base" not "qtbase" in Tumbleweed. :(
+BuildRequires:  %{qtNameAndVersion}-base-devel
+%endif
+%else
+# if not on openSUSE
+BuildRequires:  %{qtNameAndVersion}-qtbase-devel
+BuildRequires:  libappstream-glib
 %endif
 ExclusiveArch:  x86_64
 
 # RHEL 8 has the oldest point release of 5.15, and is the oldest RHEL supported.
 %if 0%{?rhel} == 8
-  Requires: qt5-qtbase >= 5.15.1
+Requires: qt5-qtbase >= 5.15.1
 %else
-  Requires: %{qtNameAndVersion}-qtbase
+Requires: %{qtNameAndVersion}-qtbase
 %endif
 
 %description
@@ -82,10 +82,10 @@ visualization of simulation output.
 %cmake -S %_vpath_srcdir -B %_vpath_builddir -DBUILD_SLIMGUI=ON
 
 %if 0%{?rhel} == 8 && "%_vpath_builddir" != "%_vpath_srcdir"
-  mkdir -p %_vpath_builddir
-  cd %_vpath_builddir
+mkdir -p %_vpath_builddir
+cd %_vpath_builddir
 %else
-  %error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
+%error The build directory is the same as the source directory; even though that shouldn't be, it is what it is!
 %endif
 
 %cmake_build

--- a/SLiM.spec
+++ b/SLiM.spec
@@ -30,7 +30,7 @@ Summary:        an evolutionary simulation framework
 
 License:        GPLv3+
 URL:            https://messerlab.org/slim/
-Source0:        https://github.com/MesserLab/SLiM/archive/v%{version}.tar.gz
+Source0:        https://github.com/bryce-carson/SLiM/archive/v%{version}.tar.gz
 
 # Prevent users of the Copr repository from using Simple Login Manager, due to binary file name conflict.
 Conflicts:      slim


### PR DESCRIPTION
The enterprise operating systems (RHEL, and the EPEL repos too) aren't building successfully with this spec file, but the failed build artifacts aren't shipped to those users so no worries.

The successfully built artifacts for Fedora and openSUSE are live and being shipped (I've already upgraded from the COPR, so we're good to go and release in my opinion).