### PR TITLE
no cron on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1
   tests-Unix-CLI:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +94,7 @@ jobs:
             cd treerec/tests && python -m pytest -xv
   
   tests-Windows-CLI:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -175,6 +177,7 @@ jobs:
             cd treerec/tests && python -m pytest -xv
   
   tests-Unix-GUI:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +230,7 @@ jobs:
           make -j 2 && make test
   
   tests-Windows-GUI:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     strategy:
       fail-fast: false
       matrix:
@@ -264,6 +268,7 @@ jobs:
           make -j 2 && make test
 
   tests-windows-latest-pacman:
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     runs-on: windows-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I recently got an email saying that regularly scheduled actions would be disabled for my SLiM fork, which surprised me - why was github running regular tests *on my fork*? Well, our github actions specifies that tests should be run every Monday at 5am, and apparently this applies to forks as well. This change should (hopefully??) make it so that the cron jobs only run on the main repo.

The first (and primary) test this works is that the jobs *are* running on this PR.