### PR TITLE
Fix Windows CI (choose correct python executable)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,10 +119,9 @@ jobs:
             msys2-devel
             mingw-w64-${{matrix.env}}-toolchain
             mingw-w64-${{matrix.env}}-cmake
-      - name: Setup Mambaforge
+      - name: Setup Miniforge3
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: anaconda-client-env
           use-mamba: true
@@ -134,21 +133,27 @@ jobs:
         shell: bash
       - name: Cache Conda env
         uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if treerec/tests/environment.yml has not changed
+          CACHE_NUMBER: 0
         with:
-          path: ${{ env.CONDA }}/envs
+          # Use faster GNU tar
+          enableCrossOsArchive: true
+          path: D:\conda_pkgs_dir
           key:
             conda-${{ runner.os }}--python-${{ matrix.python }}--${{ runner.arch }}--${{
             steps.get-date.outputs.today }}-${{
             hashFiles('treerec/tests/environment.yml') }}-${{ env.CACHE_NUMBER}}
-        env:
-          # Increase this value to reset cache if
-          # treerec/tests/environment.yml has not changed
-          CACHE_NUMBER: 0
         id: cache
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: anaconda-client-env
+          environment-file: treerec/tests/environment.yml
+          pkgs-dirs: D:\conda_pkgs_dir
       - name: Update environment
         shell: bash -el {0}
         run:
-          mamba env update -n anaconda-client-env -f treerec/tests/environment.yml
+          conda env update -n anaconda-client-env -f treerec/tests/environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Build and test (Debug)
         run: |


### PR DESCRIPTION
This PR fixes #482 

As you already said in the issue, something must have changed since the last time the tests ran. Other people have very similar issues: 

https://github.com/conda-incubator/setup-miniconda/issues/371
https://github.com/conda-incubator/setup-miniconda/issues/355 

I haven't figured out *what exactly* has changed, but I think the issue was that the correct Python executable (the one for which we installed the pytest library) was not in PATH. You cannot ssh to the GitHub action (as far as I know) so it's extremely annoying to debug. I ended up going through their documentation and updating the code according to their "best practices". Eventually, it all worked out. 