### PR TITLE
Fix mambaforge warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,13 +32,11 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: anaconda-client-env
-          use-mamba: true
           python-version: ${{ matrix.python }}
       - name: Get Date
         id: get-date
@@ -59,7 +57,7 @@ jobs:
         id: cache
       - name: Update environment
         run:
-          mamba env update -n anaconda-client-env -f treerec/tests/environment.yml
+          conda env update -n anaconda-client-env -f treerec/tests/environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Workaround for gcc-11
         if: startsWith(matrix.os, 'ubuntu') && matrix.gcc == 11
@@ -119,13 +117,11 @@ jobs:
             msys2-devel
             mingw-w64-${{matrix.env}}-toolchain
             mingw-w64-${{matrix.env}}-cmake
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           activate-environment: anaconda-client-env
-          use-mamba: true
           auto-update-conda: true
           python-version: ${{ matrix.python }}
       - name: Get Date
@@ -148,7 +144,7 @@ jobs:
       - name: Update environment
         shell: bash -el {0}
         run:
-          mamba env update -n anaconda-client-env -f treerec/tests/environment.yml
+          conda env update -n anaconda-client-env -f treerec/tests/environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Build and test (Debug)
         run: |


### PR DESCRIPTION
Currently, we get in the unix CI the following warning: 

"'Mambaforge' variants are now equivalent to 'Miniforge3'. In the future, we will ignore with a warning and use 'Miniforge3'. Eventually, using 'Mambaforge' will throw an error. Please change to 'Miniforge3' at your earliest convenience."

https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

This PR (to merge after CI in windows is fixed) moves to "miniforge" and replaces "mamba" with "conda" for consistency