### PR TITLE
Update SLiM.spec to 5.0

### DIFF
--- a/SLiM.spec
+++ b/SLiM.spec
@@ -25,13 +25,13 @@
 %endif
 
 Name:           SLiM
-Version:        4.3
+Version:        5.0
 Release:        1%{?dist}
 Summary:        an evolutionary simulation framework
 
 License:        GPLv3+
 URL:            https://messerlab.org/slim/
-Source0:        https://github.com/MesserLab/SLiM/archive/v%{version}.tar.gz
+Source0:        https://github.com/MesserLab/SLiM/archive/refs/tags/v%{version}.tar.gz
 
 # Prevent users of the Copr repository from using Simple Login Manager, due to binary file name conflict.
 Conflicts:      slim
@@ -119,6 +119,9 @@ cmake --install %_vpath_builddir --prefix %{buildroot}/usr
 %{_datadir}/mime/packages/org.messerlab.slimgui-mime.xml
 
 %changelog
+* Sat Apr 12 2025 Bryce Carson <bryce.a.carson@gmail.com> - 5.0-1
+- Bump source version to five and use the new /archive/refs/tags/v5.0 path scheme for accessing the tags on GitHub.
+
 * Sun Sep 15 2024 Bryce Carson <bryce.a.carson@gmail.com> - 4.3-2
 - Significant work has been invested into debugging the build of RHEL 8 on COPR. For whatever reason, since 4.0.1-1, we were unable to build on RHEL 8 (or perhaps it was EPEL 8?). Regardless, the ability to build on RHEL 8 and EPEL 8 has been achieved or restored, using conditionals which check what distribution the build is occuring on. These conditionals check the distribution using the defined RPM macros, a reliable system that the operating systems try not to step on each others toes; it'd be nicer if CentOS didn't call itself RHEL, though, but CentOS purposefully tries to be "bug-compatible" (if I recall) with RHEL, yet be slightly upstream of it with RHEL. The buildroot (which is the installation prefix within the CHROOT) and the source and build directories must be manually specified when building on RHEL 8 or EPEL 8 systems (which is RHEL 8 + EPEL [the extra packages for enterprise linux repository] for RHEL 8). I don't know what changed amongst the macros, if anything ever did change, but with 4.0.1-1 we were able to build for EPEL 8 two years ago, and then we weren't when I tried however long ago that issue four-hundred and forty cropped up. This has been resolved with the use of conditionals in the RPM preprocessor (do recall that "if" is not actually a macro) and RPM macros.
 - Conditionals and macros are used to decide whether to use Qt 6 or Qt 5.


### PR DESCRIPTION
Additionally utilize the new /archive/refs/tags/v%{version}.tar.gz path to the tagged version of SLiM rather the (apparently) no longer used /archive/v%{version}.tar.gz path.

This is the only work needed to prepare for the release of version five of SLiM for the Fedora-derived Linux-based operating systems.

**Remind me to enable internet access during the build on the day of the release so that OpenSUSE Tumbleweed is able to build, otherwise that chroot will fail to pull all packages from its upstream and that builder will fail. No other builds require internet access during the COPR build process.**