### PR TITLE
Fix window visibility/positioning on Windows; resolves #546

### DIFF
--- a/QtSLiM/QtSLiMExtras.cpp
+++ b/QtSLiM/QtSLiMExtras.cpp
@@ -29,6 +29,7 @@
 #include <QSizePolicy>
 #include <QGridLayout>
 #include <QLabel>
+#include <QPointer>
 #include <QLineEdit>
 #include <QSpacerItem>
 #include <QVBoxLayout>
@@ -41,6 +42,8 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
 #include <QDebug>
 #include <cmath>
 
@@ -52,6 +55,36 @@
 
 #include "eidos_value.h"
 
+
+bool QtSLiMIsMostlyOnScreen(QWidget *window)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    QRect f = window->frameGeometry();
+    QScreen *screen1 = QGuiApplication::screenAt(f.topLeft());
+    QScreen *screen2 = QGuiApplication::screenAt(f.topRight());
+    QScreen *screen3 = QGuiApplication::screenAt(f.bottomLeft());
+    QScreen *screen4 = QGuiApplication::screenAt(f.bottomRight());
+    QScreen *screen5 = QGuiApplication::screenAt(f.center());
+    int cornerCount = (!!screen1) + (!!screen2) + (!!screen3) + (!!screen4);
+    if (!screen5) cornerCount = 0;
+    return (cornerCount >= 2);
+#else
+    Q_UNUSED(window);
+    return true;
+#endif
+}
+
+void QtSLiMRelocateQuietly(QWidget *window)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    QScreen *primary = QGuiApplication::primaryScreen();
+    QRect avail = primary ? primary->availableGeometry() : QRect(0,0,1024,768);
+    window->resize(window->size().boundedTo(avail.size()));
+    window->move(avail.topLeft() + QPoint(50, 50));
+#else
+    Q_UNUSED(window);
+#endif
+}
 
 void QtSLiMMakeWindowVisibleAndExposed(QWidget *window)
 {
@@ -67,6 +100,14 @@ void QtSLiMMakeWindowVisibleAndExposed(QWidget *window)
     // I'm not sure how this is normally dealt with by operating systems, since I never use full-screen mode
     // on macOS it seems to work OK; the new window goes full-screen also, in front of the other, which
     // I assume is the standard behavior...?  I'll wait for reported bugs on this one, I don't know.  FIXME
+
+    // Fullscreen note: on Windows, "fullscreen" often means a borderless maximized window that can be
+    // overlaid by another normal window that calls show/raise/activate. We intentionally do that here so
+    // SLiMgui presents visibly on the current screen if possible, without minimizing/altering other apps.
+    // If the window still isn't exposed (e.g., truly exclusive fullscreen), we will attempt relocation to
+    // another monitor after a short delay; if that also fails, we flash the app icon to notify the user. -Chris
+
+    // Still unclear how this will behave on Linux systems, hopefuly the same as macOS?
     
     // un-miniaturize the window if it is miniaturized
     if (window->windowState() & Qt::WindowMinimized)
@@ -77,26 +118,45 @@ void QtSLiMMakeWindowVisibleAndExposed(QWidget *window)
     window->raise();
     window->activateWindow();
     
-    // check the coordinates of the window and make sure it is actually visible on-screen
-    // This requires Qt 5.10 or later
+    // If not sufficiently visible, relocate to a safe point on the primary screen
+    if (!QtSLiMIsMostlyOnScreen(window))
+        QtSLiMRelocateQuietly(window);
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    QScreen *screen1 = QGuiApplication::screenAt(window->frameGeometry().topLeft());
-    QScreen *screen2 = QGuiApplication::screenAt(window->frameGeometry().topRight());
-    QScreen *screen3 = QGuiApplication::screenAt(window->frameGeometry().bottomLeft());
-    QScreen *screen4 = QGuiApplication::screenAt(window->frameGeometry().bottomRight());
-    QScreen *screen5 = QGuiApplication::screenAt(window->frameGeometry().center());
-    int cornerCount = (!!screen1) + (!!screen2) + (!!screen3) + (!!screen4);
-    
-    if (!screen5)
-        cornerCount = 0;
-    
-    if (cornerCount >= 2)   // 2 corners plus the center are visible
-        return;
-    
-    // we're not very visible on-screen, so move ourselves so that we are; this is obviously ungraceful
-    // it would be nice to move the window to some concept of a "closest point to the current position
-    // that is fully visible", but I'm not sure how to do that, for the general case; (100, 100) seems ok
-    window->move(100, 100);
+    // If still not actually exposed (e.g., exclusive fullscreen), re-check shortly and then try other screens
+    if (QWindow *w = window->windowHandle())
+    {
+        if (!w->isExposed())
+        {
+            QPointer<QWidget> safeWindow(window);
+            QTimer::singleShot(200, qApp, [safeWindow]() {
+                if (!safeWindow)
+                    return;
+                QWidget *win = safeWindow.data();
+                QWindow *wh = win->windowHandle();
+                if (!wh)
+                    return;
+                if (wh->isExposed())
+                    return;    // became exposed in the meantime; do nothing
+
+                QScreen *currentScreen = QGuiApplication::screenAt(win->frameGeometry().center());
+                const QList<QScreen*> screens = QGuiApplication::screens();
+                for (QScreen *screen : screens)
+                {
+                    if (screen == currentScreen)
+                        continue;
+                    QRect avail = screen->availableGeometry();
+                    win->move(avail.topLeft() + QPoint(50, 50));
+                    win->raise();
+                    win->activateWindow();
+                    if (wh->isExposed())
+                        return;
+                }
+                // If we still are not exposed anywhere, alert the user via taskbar/dock
+                qApp->alert(win);
+            });
+        }
+    }
 #endif
 }
 

--- a/QtSLiM/QtSLiMExtras.h
+++ b/QtSLiM/QtSLiMExtras.h
@@ -55,6 +55,10 @@ typedef enum {
     kBottomRight
 } QtSLiM_LegendPosition;
 
+// Utility helpers for window visibility/relocation
+bool QtSLiMIsMostlyOnScreen(QWidget *window);
+void QtSLiMRelocateQuietly(QWidget *window);
+
 void QtSLiMMakeWindowVisibleAndExposed(QWidget *window);
 
 void QtSLiMClearLayout(QLayout *layout, bool deleteWidgets = true);

--- a/QtSLiM/main.cpp
+++ b/QtSLiM/main.cpp
@@ -1,6 +1,7 @@
 #include "QtSLiMAppDelegate.h"
 #include "QtSLiMWindow.h"
 #include "QtSLiMPreferences.h"
+#include "QtSLiMExtras.h"
 
 #include <QApplication>
 #include <QCommandLineParser>
@@ -319,7 +320,12 @@ int main(int argc, char *argv[])
     }
     
     if (mainWin)
+    {
         mainWin->show();
+
+        // Ensures the main window is visible and exposed on startup
+        QtSLiMMakeWindowVisibleAndExposed(mainWin);
+    }
     
     appDelegate.appDidFinishLaunching(mainWin);
     


### PR DESCRIPTION
SLiMgui, upon startup, attempts to open in the same position it was last in. However, in the case of multiple screens, this may end up being off-screen (if an external monitor was removed, for example). This commit ensures that, on startup, the main window first attempts to re-open at its last location; however, if that location is off-screen, it adjusts itself to somewhere visible. It also automatically updates its position in the event the available monitors are modified (removed, adjusted, etc.). In the event an app is open in fullscreen in the space needed to open, SLiMgui will attempt to overlay that fullscreen app. If this is not possible, it will trigger an alert on the taskbar/dock, notifying the user that the app has been opened in the background.

From what I could tell, the key problem was that `QtSLiMMakeWindowVisibleAndExposed` was not being called in `main.cpp` on startup. I think that one line may have been a complete fix. The remainder of the work is focused on improving the behavior of the windows in the context of display changes (or fullscreen apps), hopefully further avoiding visibility issues.

Resolves issue #546 