### PR TITLE
Improve CI (pin actions + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      # Batch minor/patch GitHub Actions into a single PR.
+      gha-bump:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
   coverage:
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up GCC
         run: |
           sudo apt-get install gcc-12 g++-12 && \
@@ -37,7 +37,7 @@ jobs:
           lcov --gcov-tool gcov-12 --ignore-errors gcov,mismatch --rc geninfo_unexecuted_blocks=1 --capture --directory Coverage --output-file coverage.info && \
           lcov --gcov-tool gcov-12 --ignore-errors gcov,mismatch,unused --remove coverage.info '/usr/*' '*/gsl/*' '*/eidos_zlib/*' --output-file coverage.info
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
@@ -61,9 +61,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           miniforge-version: latest
           activate-environment: anaconda-client-env
@@ -73,7 +73,7 @@ jobs:
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.CONDA }}/envs
           key:
@@ -138,9 +138,9 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup MSYS2 ${{matrix.sys}}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{matrix.sys}}
           update: true
@@ -151,7 +151,7 @@ jobs:
             mingw-w64-${{matrix.env}}-toolchain
             mingw-w64-${{matrix.env}}-cmake
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           miniforge-version: latest
           activate-environment: anaconda-client-env
@@ -162,7 +162,7 @@ jobs:
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         env:
           # Increase this value to reset cache if treerec/tests/environment.yml has not changed
           CACHE_NUMBER: 0
@@ -175,7 +175,7 @@ jobs:
             steps.get-date.outputs.today }}-${{
             hashFiles('treerec/tests/environment.yml') }}-${{ env.CACHE_NUMBER}}
         id: cache
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           activate-environment: anaconda-client-env
           environment-file: treerec/tests/environment.yml
@@ -245,7 +245,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Workaround for gcc-11
         if: startsWith(matrix.os, 'ubuntu') && matrix.gcc == 11
         run: |
@@ -260,7 +260,7 @@ jobs:
             --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc }}
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
         with:
           version: ${{ matrix.qt }}
       - name: Release build with SLiMGUI
@@ -286,9 +286,9 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup MSYS2 ${{matrix.sys}}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{matrix.sys}}
           update: true
@@ -325,9 +325,9 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup MSYS2 ${{matrix.sys}}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{matrix.sys}}
           update: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
   coverage:
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'messerlab/slim')
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up GCC
         run: |
           sudo apt-get install gcc-12 g++-12 && \
@@ -37,7 +37,7 @@ jobs:
           lcov --gcov-tool gcov-12 --ignore-errors gcov,mismatch --rc geninfo_unexecuted_blocks=1 --capture --directory Coverage --output-file coverage.info && \
           lcov --gcov-tool gcov-12 --ignore-errors gcov,mismatch,unused --remove coverage.info '/usr/*' '*/gsl/*' '*/eidos_zlib/*' --output-file coverage.info
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
@@ -61,9 +61,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           activate-environment: anaconda-client-env
@@ -73,7 +73,7 @@ jobs:
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CONDA }}/envs
           key:
@@ -138,7 +138,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup MSYS2 ${{matrix.sys}}
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -151,7 +151,7 @@ jobs:
             mingw-w64-${{matrix.env}}-toolchain
             mingw-w64-${{matrix.env}}-cmake
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           activate-environment: anaconda-client-env
@@ -162,7 +162,7 @@ jobs:
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Conda env
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           # Increase this value to reset cache if treerec/tests/environment.yml has not changed
           CACHE_NUMBER: 0
@@ -175,7 +175,7 @@ jobs:
             steps.get-date.outputs.today }}-${{
             hashFiles('treerec/tests/environment.yml') }}-${{ env.CACHE_NUMBER}}
         id: cache
-      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+      - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           activate-environment: anaconda-client-env
           environment-file: treerec/tests/environment.yml
@@ -245,7 +245,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Workaround for gcc-11
         if: startsWith(matrix.os, 'ubuntu') && matrix.gcc == 11
         run: |
@@ -286,7 +286,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup MSYS2 ${{matrix.sys}}
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -325,7 +325,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup MSYS2 ${{matrix.sys}}
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:


### PR DESCRIPTION

Hello Ben, 

I have recently learned a bit more about GitHub Actions working in a project of mine, and I have some ideas about how the current SLiM CI could be improved. 

Before, there have been issues with CI suddenly failing (see #627, #498).

I’m decently sure now that those are triggered by either (1) some minor version being released (say, for example, changing from setup-msys2@v2.31.1 to setup-msys2@v2.32.0 or (2) someone updating a git tag. Note that currently CI sometimes does not pin to any specific version, e.g. actions/cache@v3, conda-incubator/setup-miniconda@v3, etc.

I propose we change the CI to point to specific commit hashes and follow the format `username/repository@commit_hash # tag name`. 

I made that change in the [first commit of this PR](https://github.com/MesserLab/SLiM/commit/cffe57cc6468a3a70bcbf32d77529837078bcdd1). 
### Possible automation

One would have to keep track of those dependencies and update them from time to time. One automation I've found very useful is [dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions). It's basically a cron job that opens PRs with the updated dependency. The automated PRs look like this (notice that they maintain the format `commit hash # version tag` and have some useful information in the commit message)

https://github.com/currocam/SLiM/pull/5

Ideally, one would merge those PR after running the updated CI, rather than unexpectedly finding it in red. The obvious downside is that this complicates the CI more. 

### Bump versions

To avoid creating many PRs at once and running CI many times, I’ve squashed all changes from the automated PRs, so the third commit bump all the GitHub Actions to the latest version. Feel free to cherry-pick which commit (if any) you would like to merge. 

Best,
Curro