### PR TITLE
Efficient metadata

### DIFF
--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -25,7 +25,8 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post'); plt.show()
+plt.step(breakpoints, heights, where='post');
+plt.show()
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -34,4 +35,5 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post'); plt.show()
+plt.step(breakpoints, heights, where='post');
+plt.show()

--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -9,10 +9,11 @@ ts = tskit.load("decap.trees")    # no simplify!
 
 # Calculate tree heights, giving uncoalesced sites the maximum time
 def tree_heights(ts):
+    uncoalesced_height = ts.metadata['SLiM']['tick']
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
         if tree.num_roots > 1:  # not fully coalesced
-            heights[tree.index] = ts.metadata['SLiM']['tick']
+            heights[tree.index] = uncoalesced_height
         else:
             children = tree.children(tree.root)
             real_root = tree.root if len(children) > 1 else children[0]

--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 # Load the .trees file
 ts = tskit.load("decap.trees")    # no simplify!
 
-# Calculate tree heights, giving uncoalesced sites the maximum time
+# Calculate tree heights
 def tree_heights(ts):
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
@@ -25,7 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post', label="SLiM")
+plt.step(breakpoints, heights, where='post'); plt.show()
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -34,9 +34,4 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post', label="recapitated")
-plt.xlabel("genome"); plt.ylabel("time ago (generations)")
-plt.savefig("tree_heights.png")
-
-
-
+plt.step(breakpoints, heights, where='post'); plt.show()

--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -16,7 +16,7 @@ def tree_heights(ts):
             children = tree.children(roots[0])
             if len(children) == 1:
                 roots = children
-        root_heights = [tree.time(r) for r in tree.roots]
+        root_heights = [tree.time(r) for r in roots]
         assert len(set(root_heights)) == 1
         heights[tree.index] = root_heights[0]
     heights[-1] = heights[-2]  # repeat the last entry for plotting with step
@@ -25,8 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post')
-plt.show()
+plt.step(breakpoints, heights, where='post', label="SLiM")
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -35,7 +34,9 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post')
-plt.show()
+plt.step(breakpoints, heights, where='post', label="recapitated")
+plt.xlabel("genome"); plt.ylabel("time ago (generations)")
+plt.savefig("tree_heights.png")
+
 
 

--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -25,7 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post');
+plt.step(breakpoints, heights, where='post')
 plt.show()
 
 # Recapitate!
@@ -35,5 +35,5 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post');
+plt.step(breakpoints, heights, where='post')
 plt.show()

--- a/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/QtSLiM/recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -9,15 +9,16 @@ ts = tskit.load("decap.trees")    # no simplify!
 
 # Calculate tree heights, giving uncoalesced sites the maximum time
 def tree_heights(ts):
-    uncoalesced_height = ts.metadata['SLiM']['tick']
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
-        if tree.num_roots > 1:  # not fully coalesced
-            heights[tree.index] = uncoalesced_height
-        else:
-            children = tree.children(tree.root)
-            real_root = tree.root if len(children) > 1 else children[0]
-            heights[tree.index] = tree.time(real_root)
+        roots = tree.roots
+        if len(roots) == 1:
+            children = tree.children(roots[0])
+            if len(children) == 1:
+                roots = children
+        root_heights = [tree.time(r) for r in tree.roots]
+        assert len(set(root_heights)) == 1
+        heights[tree.index] = root_heights[0]
     heights[-1] = heights[-2]  # repeat the last entry for plotting with step
     return heights
 

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -25,7 +25,8 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post'); plt.show()
+plt.step(breakpoints, heights, where='post');
+plt.show()
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -34,4 +35,5 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post'); plt.show()
+plt.step(breakpoints, heights, where='post');
+plt.show()

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -9,10 +9,11 @@ ts = tskit.load("decap.trees")    # no simplify!
 
 # Calculate tree heights, giving uncoalesced sites the maximum time
 def tree_heights(ts):
+    uncoalesced_height = ts.metadata['SLiM']['tick']
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
         if tree.num_roots > 1:  # not fully coalesced
-            heights[tree.index] = ts.metadata['SLiM']['tick']
+            heights[tree.index] = uncoalesced_height
         else:
             children = tree.children(tree.root)
             real_root = tree.root if len(children) > 1 else children[0]

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 # Load the .trees file
 ts = tskit.load("decap.trees")    # no simplify!
 
-# Calculate tree heights, giving uncoalesced sites the maximum time
+# Calculate tree heights
 def tree_heights(ts):
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
@@ -25,7 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post', label="SLiM")
+plt.step(breakpoints, heights, where='post'); plt.show()
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -34,9 +34,4 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post', label="recapitated")
-plt.xlabel("genome"); plt.ylabel("time ago (generations)")
-plt.savefig("tree_heights.png")
-
-
-
+plt.step(breakpoints, heights, where='post'); plt.show()

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -16,7 +16,7 @@ def tree_heights(ts):
             children = tree.children(roots[0])
             if len(children) == 1:
                 roots = children
-        root_heights = [tree.time(r) for r in tree.roots]
+        root_heights = [tree.time(r) for r in roots]
         assert len(set(root_heights)) == 1
         heights[tree.index] = root_heights[0]
     heights[-1] = heights[-2]  # repeat the last entry for plotting with step
@@ -25,8 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post')
-plt.show()
+plt.step(breakpoints, heights, where='post', label="SLiM")
 
 # Recapitate!
 recap = pyslim.recapitate(ts, ancestral_Ne=1e5, recombination_rate=3e-10, random_seed=1)
@@ -35,7 +34,9 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post')
-plt.show()
+plt.step(breakpoints, heights, where='post', label="recapitated")
+plt.xlabel("genome"); plt.ylabel("time ago (generations)")
+plt.savefig("tree_heights.png")
+
 
 

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -25,7 +25,7 @@ def tree_heights(ts):
 # Plot tree heights before recapitation
 breakpoints = list(ts.breakpoints())
 heights = tree_heights(ts)
-plt.step(breakpoints, heights, where='post');
+plt.step(breakpoints, heights, where='post')
 plt.show()
 
 # Recapitate!
@@ -35,5 +35,5 @@ recap.dump("recap.trees")
 # Plot the tree heights after recapitation
 breakpoints = list(recap.breakpoints())
 heights = tree_heights(recap)
-plt.step(breakpoints, heights, where='post');
+plt.step(breakpoints, heights, where='post')
 plt.show()

--- a/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/SLiMgui/Recipes/Recipe 18.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -9,15 +9,16 @@ ts = tskit.load("decap.trees")    # no simplify!
 
 # Calculate tree heights, giving uncoalesced sites the maximum time
 def tree_heights(ts):
-    uncoalesced_height = ts.metadata['SLiM']['tick']
     heights = np.zeros(ts.num_trees + 1)
     for tree in ts.trees():
-        if tree.num_roots > 1:  # not fully coalesced
-            heights[tree.index] = uncoalesced_height
-        else:
-            children = tree.children(tree.root)
-            real_root = tree.root if len(children) > 1 else children[0]
-            heights[tree.index] = tree.time(real_root)
+        roots = tree.roots
+        if len(roots) == 1:
+            children = tree.children(roots[0])
+            if len(children) == 1:
+                roots = children
+        root_heights = [tree.time(r) for r in tree.roots]
+        assert len(set(root_heights)) == 1
+        heights[tree.index] = root_heights[0]
     heights[-1] = heights[-2]  # repeat the last entry for plotting with step
     return heights
 

--- a/VERSIONS
+++ b/VERSIONS
@@ -204,6 +204,7 @@ multitrait branch:
 	add a built-in "Multispecies Multitrait Phenotype ~ Time" plot for phenotype ~ time, with one line per trait across all species
 	add a built-in "Phenotype ~ Time" plot for phenotype ~ time, focusing on a single user-selected trait across subpopulations
 	clean up the way pedigree IDs get recorded, for better efficiency and parallelization
+	fix recipe 18.10 to reduce metadata accesses (see discussion at https://github.com/tskit-dev/tskit/issues/3472#issuecomment-5210734749)
 
 
 version 5.2 (Eidos version 4.2):


### PR DESCRIPTION
Draft fix to make metadata access efficient in recipe 18.10; see https://github.com/tskit-dev/tskit/issues/3472#issuecomment-5210734749.

@petrelharp The function that uses the metadata gets called twice in this script, so it still accesses the metadata twice.  I wasn't sure whether it would make sense to define a global, or pass the value as a parameter, etc., to get the number of metadata accesses down to one; for this script it seems like overkill, but maybe it would provide a better example in terms of pedagogy – really emphasizing that users should try to get their metadata accesses down to the bare minimum.  Let me know what you think the best thing is here.

Once this PR is finalized and approved I'll modify the manual's discussion of this recipe to emphasize that minimizing metadata access is important.  :->